### PR TITLE
修复修改物品时，过期日期会消失的问题

### DIFF
--- a/lib/blocs/storage/item_edit/item_edit_bloc.dart
+++ b/lib/blocs/storage/item_edit/item_edit_bloc.dart
@@ -71,7 +71,7 @@ class ItemEditBloc extends Bloc<ItemEditEvent, ItemEditState> {
         }
         // 从物品管理主页进入
         if (storageHomeBloc != null) {
-          storageHomeBloc.add(StorageHomeChanged(itemType: ItemType.all));
+          storageHomeBloc.add(StorageHomeRefreshed(itemType: ItemType.all));
         }
         // 从搜索界面进入
         if (storageSearchBloc != null) {

--- a/lib/pages/storage/item_edit_page.dart
+++ b/lib/pages/storage/item_edit_page.dart
@@ -269,6 +269,7 @@ class _ItemEditPageState extends State<ItemEditPage> {
       _descriptionController =
           TextEditingController(text: widget.item.description);
       storageId = widget.item.storage.id;
+      expirationDate = widget.item.expirationDate;
     } else {
       _nameController = TextEditingController();
       _numberController = TextEditingController(text: '1');


### PR DESCRIPTION
看来是忘记给修改页面的过期日期赋初值的原因。这个同时也导致了修改物品时，过期日期会消失。