### PR TITLE
fix(topic): 修复切换评论排序时无法加载的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复留言板切换评论排序时无法加载的问题
+
 ## [0.8.2] - 2021-11-21
 
 ### Added

--- a/lib/board/view/topic_detail_page.dart
+++ b/lib/board/view/topic_detail_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
-import 'package:smarthome/app/settings/settings_controller.dart';
 import 'package:smarthome/board/bloc/blocs.dart';
 import 'package:smarthome/board/model/models.dart';
 import 'package:smarthome/board/repository/board_repository.dart';
@@ -9,6 +8,7 @@ import 'package:smarthome/board/view/topic_edit_page.dart';
 import 'package:smarthome/board/view/widgets/add_comment_bar.dart';
 import 'package:smarthome/board/view/widgets/comment_item.dart';
 import 'package:smarthome/board/view/widgets/topic_item.dart';
+import 'package:smarthome/app/settings/settings_controller.dart';
 import 'package:smarthome/user/user.dart';
 import 'package:smarthome/utils/show_snack_bar.dart';
 import 'package:smarthome/widgets/center_loading_indicator.dart';
@@ -153,7 +153,6 @@ class _DetailScreen extends StatelessWidget {
                     child: InfiniteList<Comment>(
                       items: state.comments,
                       itemBuilder: (context, item) => CommentItem(
-                        key: ValueKey(item.id),
                         comment: item,
                         showMenu: loginUser == item.user,
                       ),

--- a/lib/board/view/topic_detail_page.dart
+++ b/lib/board/view/topic_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+import 'package:smarthome/app/settings/settings_controller.dart';
 import 'package:smarthome/board/bloc/blocs.dart';
 import 'package:smarthome/board/model/models.dart';
 import 'package:smarthome/board/repository/board_repository.dart';
@@ -8,7 +9,6 @@ import 'package:smarthome/board/view/topic_edit_page.dart';
 import 'package:smarthome/board/view/widgets/add_comment_bar.dart';
 import 'package:smarthome/board/view/widgets/comment_item.dart';
 import 'package:smarthome/board/view/widgets/topic_item.dart';
-import 'package:smarthome/app/settings/settings_controller.dart';
 import 'package:smarthome/user/user.dart';
 import 'package:smarthome/utils/show_snack_bar.dart';
 import 'package:smarthome/widgets/center_loading_indicator.dart';
@@ -153,6 +153,7 @@ class _DetailScreen extends StatelessWidget {
                     child: InfiniteList<Comment>(
                       items: state.comments,
                       itemBuilder: (context, item) => CommentItem(
+                        key: ValueKey(item.id),
                         comment: item,
                         showMenu: loginUser == item.user,
                       ),

--- a/lib/board/view/widgets/comment_item.dart
+++ b/lib/board/view/widgets/comment_item.dart
@@ -48,7 +48,8 @@ class CommentItem extends StatelessWidget {
                             TextButton(
                               onPressed: () {
                                 showInfoSnackBar('正在删除...', duration: 1);
-                                BlocProvider.of<CommentEditBloc>(context)
+                                context
+                                    .read<CommentEditBloc>()
                                     .add(CommentDeleted(comment: comment));
                                 Navigator.pop(context);
                               },

--- a/lib/board/view/widgets/comment_item.dart
+++ b/lib/board/view/widgets/comment_item.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:smarthome/app/settings/settings_controller.dart';
 import 'package:smarthome/board/bloc/blocs.dart';
 import 'package:smarthome/board/model/board.dart';
 import 'package:smarthome/board/repository/board_repository.dart';
 import 'package:smarthome/board/view/comment_edit_page.dart';
 import 'package:smarthome/board/view/widgets/item_title.dart';
 import 'package:smarthome/core/core.dart';
-import 'package:smarthome/app/settings/settings_controller.dart';
 import 'package:smarthome/utils/show_snack_bar.dart';
 
 class CommentItem extends StatelessWidget {
@@ -22,81 +22,79 @@ class CommentItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final descending = context
-        .select((SettingsController settings) => settings.commentDescending);
-    return Container(
-      key: ValueKey(comment.id),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          ItemTitle(
-            user: comment.user,
-            editedAt: comment.editedAt,
-            onSelected: showMenu
-                ? (Menu menu) async {
-                    switch (menu) {
-                      case Menu.delete:
-                        await showDialog(
-                          context: context,
-                          builder: (_) => AlertDialog(
-                            title: const Text('删除评论'),
-                            content: const Text('你确认要删除该评论？'),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () {
-                                  Navigator.of(context).pop();
-                                },
-                                child: const Text('否'),
-                              ),
-                              TextButton(
-                                onPressed: () {
-                                  showInfoSnackBar('正在删除...', duration: 1);
-                                  BlocProvider.of<CommentEditBloc>(context)
-                                      .add(CommentDeleted(comment: comment));
-                                  Navigator.pop(context);
-                                },
-                                child: const Text('是'),
-                              ),
-                            ],
-                          ),
-                        );
-                        break;
-                      case Menu.edit:
-                        await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => BlocProvider(
-                              create: (context) => CommentEditBloc(
-                                  boardRepository:
-                                      RepositoryProvider.of<BoardRepository>(
-                                          context)),
-                              child: CommentEditPage(
-                                isEditing: true,
-                                comment: comment,
-                              ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ItemTitle(
+          user: comment.user,
+          editedAt: comment.editedAt,
+          onSelected: showMenu
+              ? (Menu menu) async {
+                  switch (menu) {
+                    case Menu.delete:
+                      await showDialog(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          title: const Text('删除评论'),
+                          content: const Text('你确认要删除该评论？'),
+                          actions: <Widget>[
+                            TextButton(
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                              child: const Text('否'),
+                            ),
+                            TextButton(
+                              onPressed: () {
+                                showInfoSnackBar('正在删除...', duration: 1);
+                                BlocProvider.of<CommentEditBloc>(context)
+                                    .add(CommentDeleted(comment: comment));
+                                Navigator.pop(context);
+                              },
+                              child: const Text('是'),
+                            ),
+                          ],
+                        ),
+                      );
+                      break;
+                    case Menu.edit:
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => BlocProvider(
+                            create: (context) => CommentEditBloc(
+                                boardRepository:
+                                    RepositoryProvider.of<BoardRepository>(
+                                        context)),
+                            child: CommentEditPage(
+                              isEditing: true,
+                              comment: comment,
                             ),
                           ),
-                        );
-                        BlocProvider.of<TopicDetailBloc>(context)
-                            .add(TopicDetailFetched(
-                          descending: descending,
-                          cache: false,
-                        ));
-                        break;
-                    }
+                        ),
+                      );
+                      final descending =
+                          context.read<SettingsController>().commentDescending;
+                      context.read<TopicDetailBloc>().add(
+                            TopicDetailFetched(
+                              descending: descending,
+                              cache: false,
+                            ),
+                          );
+                      break;
                   }
-                : null,
+                }
+              : null,
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+          child: MarkdownBody(
+            data: comment.body!,
+            selectable: true,
           ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
-            child: MarkdownBody(
-              data: comment.body!,
-              selectable: true,
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
具体原因，我没能理解。看解决方法，应该是 Widget Tree 更新相关的问题。

删掉 CommentItem 中的一个 ValueKey 就一些正常了。 