### PR TITLE
fix: 修复耗材选择框没法搜索到对应物品的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复耗材选择框没法搜索到对应物品的问题
+
 ## [0.9.2] - 2023-01-01
 
 ### Changed

--- a/lib/widgets/dropdown_search.dart
+++ b/lib/widgets/dropdown_search.dart
@@ -28,6 +28,7 @@ class MyDropdownSearch<T> extends StatelessWidget {
     return DropdownSearch<T>(
       compareFn: (i1, i2) => i1 == i2,
       popupProps: PopupProps.menu(
+        isFilterOnline: true,
         showSelectedItems: true,
         showSearchBox: true,
         itemBuilder: (ctx, item, isSelected) {


### PR DESCRIPTION
原来是 DropdownSearch 没有设置 isFilterOnline 为 true。