### PR TITLE
chore(deps): upgrade Flutter to 3.44.0 and Riverpod packages

### DIFF
--- a/.agents/skills/flutter-add-integration-test/SKILL.md
+++ b/.agents/skills/flutter-add-integration-test/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: flutter-add-integration-test
+description: Configures Flutter Driver for app interaction and converts MCP actions into permanent integration tests. Use when adding integration testing to a project, exploring UI components via MCP, or automating user flows with the integration_test package.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 18:29:20 GMT
+---
+# Implementing Flutter Integration Tests
+
+## Contents
+- [Project Setup and Dependencies](#project-setup-and-dependencies)
+- [Interactive Exploration via MCP](#interactive-exploration-via-mcp)
+- [Test Authoring Guidelines](#test-authoring-guidelines)
+- [Execution and Profiling](#execution-and-profiling)
+- [Workflow: End-to-End Integration Testing](#workflow-end-to-end-integration-testing)
+- [Examples](#examples)
+
+## Project Setup and Dependencies
+
+Configure the project to support integration testing and Flutter Driver extensions.
+
+1. Add required development dependencies to `pubspec.yaml`:
+   ```bash
+   flutter pub add 'dev:integration_test:{"sdk":"flutter"}'
+   flutter pub add 'dev:flutter_test:{"sdk":"flutter"}'
+   ```
+2. Enable the Flutter Driver extension in your application entry point (typically `lib/main.dart` or a dedicated `lib/main_test.dart`):
+   - Import `package:flutter_driver/driver_extension.dart`.
+   - Call `enableFlutterDriverExtension();` before `runApp()`.
+3. Add `Key` parameters (e.g., `ValueKey('login_button')`) to critical widgets in the application code to ensure reliable targeting during tests.
+
+## Interactive Exploration via MCP
+
+Use the Dart/Flutter MCP server tools to interactively explore and manipulate the application state before writing static tests.
+
+- **Launch**: Execute `launch_app` with `target: "lib/main_test.dart"` to start the application and acquire the DTD URI.
+- **Inspect**: Execute `get_widget_tree` to discover available `Key`s, `Text` nodes, and widget `Type`s.
+- **Interact**: Execute `tap`, `enter_text`, and `scroll` to simulate user flows.
+- **Wait**: Always execute `waitFor` or verify state with `get_health` when navigating or triggering animations.
+- **Troubleshoot Unmounted Widgets**: If a widget is not found in the tree, it may be lazily loaded in a `SliverList` or `ListView`. Execute `scroll` or `scrollIntoView` to force the widget to mount before interacting with it.
+
+## Test Authoring Guidelines
+
+Structure integration tests using the `flutter_test` API paradigm. 
+
+- Create a dedicated `integration_test/` directory at the project root.
+- Name all test files using the `<name>_test.dart` convention.
+- Initialize the binding by calling `IntegrationTestWidgetsFlutterBinding.ensureInitialized();` at the start of `main()`.
+- Load the application UI using `await tester.pumpWidget(MyApp());`.
+- Trigger frames and wait for animations to complete using `await tester.pumpAndSettle();` after interactions like `tester.tap()`.
+- Assert widget visibility using `expect(find.byKey(ValueKey('foo')), findsOneWidget);` or `findsNothing`.
+- Scroll to specific off-screen widgets using `await tester.scrollUntilVisible(itemFinder, 500.0, scrollable: listFinder);`.
+
+**Conditional Logic for Legacy `flutter_driver`:**
+- If maintaining or migrating legacy `flutter_driver` tests, use `driver.waitFor()`, `driver.waitForAbsent()`, `driver.tap()`, and `driver.scroll()` instead of the `WidgetTester` APIs.
+
+## Execution and Profiling
+
+Execute tests using the `flutter drive` command. Require a host driver script located in `test_driver/integration_test.dart` that calls `integrationDriver()`.
+
+**Conditional Execution Targets:**
+- **If testing on Chrome:** Launch `chromedriver --port=4444` in a separate terminal, then run:
+  `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart -d chrome`
+- **If testing headless web:** Run with `-d web-server`.
+- **If testing on Android (Local):** Run `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart`.
+- **If testing on Firebase Test Lab (Android):** 
+  1. Build debug APK: `flutter build apk --debug`
+  2. Build test APK: `./gradlew app:assembleAndroidTest`
+  3. Upload both APKs to the Firebase Test Lab console.
+
+## Workflow: End-to-End Integration Testing
+
+Copy and follow this checklist to implement and verify integration tests.
+
+- [ ] **Task Progress: Setup**
+  - [ ] Add `integration_test` and `flutter_test` to `pubspec.yaml`.
+  - [ ] Inject `enableFlutterDriverExtension()` into the app entry point.
+  - [ ] Assign `ValueKey`s to target widgets.
+- [ ] **Task Progress: Exploration**
+  - [ ] Run `launch_app` via MCP.
+  - [ ] Map the widget tree using `get_widget_tree`.
+  - [ ] Validate interaction paths using MCP tools (`tap`, `enter_text`).
+- [ ] **Task Progress: Authoring**
+  - [ ] Create `integration_test/app_test.dart`.
+  - [ ] Write test cases using `WidgetTester` APIs.
+  - [ ] Create `test_driver/integration_test.dart` with `integrationDriver()`.
+- [ ] **Task Progress: Execution & Feedback Loop**
+  - [ ] Run `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart`.
+  - [ ] **Feedback Loop**: Review test output -> If `PumpAndSettleTimedOutException` occurs, check for infinite animations -> If widget not found, add `scrollUntilVisible` -> Re-run test until passing.
+
+## Examples
+
+### Standard Integration Test (`integration_test/app_test.dart`)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:my_app/main.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('End-to-end test', () {
+    testWidgets('tap on the floating action button, verify counter', (tester) async {
+      // Load app widget.
+      await tester.pumpWidget(const MyApp());
+
+      // Verify the counter starts at 0.
+      expect(find.text('0'), findsOneWidget);
+
+      // Find the floating action button to tap on.
+      final fab = find.byKey(const ValueKey('increment'));
+
+      // Emulate a tap on the floating action button.
+      await tester.tap(fab);
+
+      // Trigger a frame and wait for animations.
+      await tester.pumpAndSettle();
+
+      // Verify the counter increments by 1.
+      expect(find.text('1'), findsOneWidget);
+    });
+  });
+}
+```
+
+### Host Driver Script (`test_driver/integration_test.dart`)
+
+```dart
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();
+```
+
+### Performance Profiling Driver Script (`test_driver/perf_driver.dart`)
+
+Use this driver script if you wrap your test actions in `binding.traceAction()` to capture performance metrics.
+
+```dart
+import 'package:flutter_driver/flutter_driver.dart' as driver;
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() {
+  return integrationDriver(
+    responseDataCallback: (data) async {
+      if (data != null) {
+        final timeline = driver.Timeline.fromJson(
+          data['scrolling_timeline'] as Map<String, dynamic>,
+        );
+
+        final summary = driver.TimelineSummary.summarize(timeline);
+
+        await summary.writeTimelineToFile(
+          'scrolling_timeline',
+          pretty: true,
+          includeSummary: true,
+        );
+      }
+    },
+  );
+}
+```

--- a/.agents/skills/flutter-add-widget-preview/SKILL.md
+++ b/.agents/skills/flutter-add-widget-preview/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: flutter-add-widget-preview
+description: Adds interactive widget previews to the project using the previews.dart system. Use when creating new UI components or updating existing screens to ensure consistent design and interactive testing.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 20:05:23 GMT
+---
+# Previewing Flutter Widgets
+
+## Contents
+- [Preview Guidelines](#preview-guidelines)
+- [Handling Limitations](#handling-limitations)
+- [Workflows](#workflows)
+- [Examples](#examples)
+
+## Preview Guidelines
+
+Use the Flutter Widget Previewer to render widgets in real-time, isolated from the full application context. 
+
+- **Target Elements:** Apply the `@Preview` annotation to top-level functions, static methods within a class, or public widget constructors/factories that have no required arguments and return a `Widget` or `WidgetBuilder`.
+- **Imports:** Always import `package:flutter/widget_previews.dart` to access the preview annotations.
+- **Custom Annotations:** Extend the `Preview` class to create custom annotations that inject common properties (e.g., themes, wrappers) across multiple widgets.
+- **Multiple Configurations:** Apply multiple `@Preview` annotations to a single target to generate multiple preview instances. Alternatively, extend `MultiPreview` to encapsulate common multi-preview configurations.
+- **Runtime Transformations:** Override the `transform()` method in custom `Preview` or `MultiPreview` classes to modify preview configurations dynamically at runtime (e.g., generating names based on dynamic values, which is impossible in a `const` context).
+
+## Handling Limitations
+
+Adhere to the following constraints when authoring previewable widgets, as the Widget Previewer runs in a web environment:
+
+- **No Native APIs:** Do not use native plugins or APIs from `dart:io` or `dart:ffi`. Widgets with transitive dependencies on `dart:io` or `dart:ffi` will throw exceptions upon invocation. Use conditional imports to mock or bypass these in preview mode.
+- **Asset Paths:** Use package-based paths for assets loaded via `dart:ui` `fromAsset` APIs (e.g., `packages/my_package_name/assets/my_image.png` instead of `assets/my_image.png`).
+- **Public Callbacks:** Ensure all callback arguments provided to preview annotations are public and constant to satisfy code generation requirements.
+- **Constraints:** Apply explicit constraints using the `size` parameter in the `@Preview` annotation if your widget is unconstrained, as the previewer defaults to constraining them to approximately half the viewport.
+
+## Workflows
+
+### Creating a Widget Preview
+Copy and track this checklist when implementing a new widget preview:
+
+- [ ] Import `package:flutter/widget_previews.dart`.
+- [ ] Identify a valid target (top-level function, static method, or parameter-less public constructor).
+- [ ] Apply the `@Preview` annotation to the target.
+- [ ] Configure preview parameters (`name`, `group`, `size`, `theme`, `brightness`, etc.) as needed.
+- [ ] If applying the same configuration to multiple widgets, extract the configuration into a custom class extending `Preview`.
+
+### Interacting with Previews
+Follow the appropriate conditional workflow to launch and interact with the Widget Previewer:
+
+**If using a supported IDE (Android Studio, IntelliJ, VS Code with Flutter 3.38+):**
+1. Launch the IDE. The Widget Previewer starts automatically.
+2. Open the "Flutter Widget Preview" tab in the sidebar.
+3. Toggle "Filter previews by selected file" at the bottom left if you want to view previews outside the currently active file.
+
+**If using the Command Line:**
+1. Navigate to the Flutter project's root directory.
+2. Run `flutter widget-preview start`.
+3. View the automatically opened Chrome environment.
+
+**Feedback Loop: Preview Iteration**
+1. Modify the widget code or preview configuration.
+2. Observe the automatic update in the Widget Previewer.
+3. If global state (e.g., static initializers) was modified: Click the global hot restart button at the bottom right.
+4. If only the local widget state needs resetting: Click the individual hot restart button on the specific preview card.
+5. Review errors in the IDE/CLI console -> fix -> repeat.
+
+## Examples
+
+### Basic Preview
+```dart
+import 'package:flutter/widget_previews.dart';
+import 'package:flutter/material.dart';
+
+@Preview(name: 'My Sample Text', group: 'Typography')
+Widget mySampleText() {
+  return const Text('Hello, World!');
+}
+```
+
+### Custom Preview with Runtime Transformation
+```dart
+import 'package:flutter/widget_previews.dart';
+import 'package:flutter/material.dart';
+
+final class TransformativePreview extends Preview {
+  const TransformativePreview({
+    super.name,
+    super.group,
+  });
+
+  PreviewThemeData _themeBuilder() {
+    return PreviewThemeData(
+      materialLight: ThemeData.light(),
+      materialDark: ThemeData.dark(),
+    );
+  }
+
+  @override
+  Preview transform() {
+    final originalPreview = super.transform();
+    final builder = originalPreview.toBuilder();
+    
+    builder
+      ..name = 'Transformed - ${originalPreview.name}'
+      ..theme = _themeBuilder;
+
+    return builder.toPreview();
+  }
+}
+
+@TransformativePreview(name: 'Custom Themed Button')
+Widget myButton() => const ElevatedButton(onPressed: null, child: Text('Click'));
+```
+
+### MultiPreview Implementation
+```dart
+import 'package:flutter/widget_previews.dart';
+import 'package:flutter/material.dart';
+
+/// Creates light and dark mode previews automatically.
+final class MultiBrightnessPreview extends MultiPreview {
+  const MultiBrightnessPreview({required this.name});
+
+  final String name;
+
+  @override
+  List<Preview> get previews => const [
+        Preview(brightness: Brightness.light),
+        Preview(brightness: Brightness.dark),
+      ];
+
+  @override
+  List<Preview> transform() {
+    final previews = super.transform();
+    return previews.map((preview) {
+      final builder = preview.toBuilder()
+        ..group = 'Brightness'
+        ..name = '$name - ${preview.brightness!.name}';
+      return builder.toPreview();
+    }).toList();
+  }
+}
+
+@MultiBrightnessPreview(name: 'Primary Card')
+Widget cardPreview() => const Card(child: Padding(padding: EdgeInsets.all(8.0), child: Text('Content')));
+```

--- a/.agents/skills/flutter-add-widget-test/SKILL.md
+++ b/.agents/skills/flutter-add-widget-test/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: flutter-add-widget-test
+description: Implement a component-level test using `WidgetTester` to verify UI rendering and user interactions (tapping, scrolling, entering text). Use when validating that a specific widget displays correct data and responds to events as expected.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 21:15:41 GMT
+---
+# Writing Flutter Widget Tests
+
+## Contents
+- [Setup & Configuration](#setup--configuration)
+- [Core Components](#core-components)
+- [Workflow: Implementing a Widget Test](#workflow-implementing-a-widget-test)
+- [Interaction & State Management](#interaction--state-management)
+- [Examples](#examples)
+
+## Setup & Configuration
+
+Ensure the testing environment is properly configured before authoring widget tests.
+
+1. Add the `flutter_test` dependency to the `dev_dependencies` section of `pubspec.yaml`.
+2. Place all test files in the `test/` directory at the root of the project.
+3. Suffix all test file names with `_test.dart` (e.g., `widget_test.dart`).
+
+## Core Components
+
+Utilize the following `flutter_test` components to interact with and validate the widget tree:
+
+*   **`WidgetTester`**: The primary interface for building and interacting with widgets in the test environment. Provided automatically by the `testWidgets()` function.
+*   **`Finder`**: Locates widgets in the test environment (e.g., `find.text('Submit')`, `find.byType(TextField)`, `find.byKey(Key('submit_btn'))`).
+*   **`Matcher`**: Verifies the presence or state of widgets located by a `Finder` (e.g., `findsOneWidget`, `findsNothing`, `findsNWidgets(2)`, `matchesGoldenFile`).
+
+## Workflow: Implementing a Widget Test
+
+Copy the following checklist to track progress when implementing a new widget test.
+
+### Task Progress
+- [ ] **Step 1: Define the test.** Use `testWidgets('description', (WidgetTester tester) async { ... })`.
+- [ ] **Step 2: Build the widget.** Call `await tester.pumpWidget(MyWidget())` to render the UI. Wrap the widget in a `MaterialApp` or `Directionality` widget if it requires inherited directional or theme data.
+- [ ] **Step 3: Locate elements.** Instantiate `Finder` objects for the target widgets.
+- [ ] **Step 4: Verify initial state.** Use `expect(finder, matcher)` to validate the initial render.
+- [ ] **Step 5: Simulate interactions.** Execute gestures or inputs (e.g., `await tester.tap(buttonFinder)`).
+- [ ] **Step 6: Rebuild the tree.** Call `await tester.pump()` or `await tester.pumpAndSettle()` to process state changes.
+- [ ] **Step 7: Verify updated state.** Use `expect()` to validate the UI after the interaction.
+- [ ] **Step 8: Run and validate.** Execute `flutter test test/your_test_file_test.dart`.
+- [ ] **Step 9: Feedback Loop.** Review test output -> identify failing matchers -> adjust widget logic or test assertions -> re-run until passing.
+
+## Interaction & State Management
+
+Apply the following conditional logic based on the type of interaction or state change being tested:
+
+*   **If testing static rendering:** Call `await tester.pumpWidget()` once, then immediately run `expect()` assertions.
+*   **If testing standard state changes (e.g., button taps):** 
+    1. Call `await tester.tap(finder)`.
+    2. Call `await tester.pump()` to trigger a single frame rebuild.
+*   **If testing animations, transitions, or asynchronous UI updates:** 
+    1. Trigger the action (e.g., `await tester.drag(finder, Offset(500, 0))`).
+    2. Call `await tester.pumpAndSettle()` to repeatedly pump frames until no more frames are scheduled (animation completes).
+*   **If testing text input:** Call `await tester.enterText(textFieldFinder, 'Input string')`.
+*   **If testing items in a dynamic or long list:** Call `await tester.scrollUntilVisible(itemFinder, 500.0, scrollable: listFinder)` to ensure the target widget is rendered before interacting with it.
+
+## Examples
+
+### High-Fidelity Widget Test Implementation
+
+**Target Widget (`lib/todo_list.dart`):**
+```dart
+import 'package:flutter/material.dart';
+
+class TodoList extends StatefulWidget {
+  const TodoList({super.key});
+
+  @override
+  State<TodoList> createState() => _TodoListState();
+}
+
+class _TodoListState extends State<TodoList> {
+  final todos = <String>[];
+  final controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            TextField(controller: controller),
+            Expanded(
+              child: ListView.builder(
+                itemCount: todos.length,
+                itemBuilder: (context, index) {
+                  final todo = todos[index];
+                  return Dismissible(
+                    key: Key('$todo$index'),
+                    onDismissed: (_) => setState(() => todos.removeAt(index)),
+                    child: ListTile(title: Text(todo)),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            setState(() {
+              todos.add(controller.text);
+              controller.clear();
+            });
+          },
+          child: const Icon(Icons.add),
+        ),
+      ),
+    );
+  }
+}
+```
+
+**Test Implementation (`test/todo_list_test.dart`):**
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_app/todo_list.dart';
+
+void main() {
+  testWidgets('Add and remove a todo item', (WidgetTester tester) async {
+    // 1. Build the widget
+    await tester.pumpWidget(const TodoList());
+
+    // 2. Verify initial state
+    expect(find.byType(ListTile), findsNothing);
+
+    // 3. Enter text into the TextField
+    await tester.enterText(find.byType(TextField), 'Buy groceries');
+
+    // 4. Tap the add button
+    await tester.tap(find.byType(FloatingActionButton));
+
+    // 5. Rebuild the widget to reflect the new state
+    await tester.pump();
+
+    // 6. Verify the item was added
+    expect(find.text('Buy groceries'), findsOneWidget);
+
+    // 7. Swipe the item to dismiss it
+    await tester.drag(find.byType(Dismissible), const Offset(500, 0));
+
+    // 8. Build the widget until the dismiss animation ends
+    await tester.pumpAndSettle();
+
+    // 9. Verify the item was removed
+    expect(find.text('Buy groceries'), findsNothing);
+  });
+}
+```

--- a/.agents/skills/flutter-apply-architecture-best-practices/SKILL.md
+++ b/.agents/skills/flutter-apply-architecture-best-practices/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: flutter-apply-architecture-best-practices
+description: Architects a Flutter application using the recommended layered approach (UI, Logic, Data). Use when structuring a new project or refactoring for scalability.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 20:11:20 GMT
+---
+# Architecting Flutter Applications
+
+## Contents
+- [Architectural Layers](#architectural-layers)
+- [Project Structure](#project-structure)
+- [Workflow: Implementing a New Feature](#workflow-implementing-a-new-feature)
+- [Examples](#examples)
+
+## Architectural Layers
+
+Enforce strict Separation of Concerns by dividing the application into distinct layers. Never mix UI rendering with business logic or data fetching.
+
+### UI Layer (Presentation)
+Implement the MVVM (Model-View-ViewModel) pattern to manage UI state and logic.
+*   **Views:** Write reusable, lean widgets. Restrict logic in Views to UI-specific operations (e.g., animations, layout constraints, simple routing). Pass all required data from the ViewModel.
+*   **ViewModels:** Manage UI state and handle user interactions. Extend `ChangeNotifier` (or use `Listenable`) to expose state. Expose immutable state snapshots to the View. Inject Repositories into ViewModels via the constructor.
+
+### Data Layer
+Implement the Repository pattern to isolate data access logic and create a single source of truth.
+*   **Services:** Create stateless classes to wrap external APIs (HTTP clients, local databases, platform plugins). Return raw API models or `Result` wrappers.
+*   **Repositories:** Consume one or more Services. Transform raw API models into clean Domain Models. Handle caching, offline synchronization, and retry logic. Expose Domain Models to ViewModels.
+
+### Logic Layer (Domain - Optional)
+*   **Use Cases:** Implement this layer only if the application contains complex business logic that clutters the ViewModel, or if logic must be reused across multiple ViewModels. Extract this logic into dedicated Use Case (interactor) classes that sit between ViewModels and Repositories.
+
+## Project Structure
+
+Organize the codebase using a hybrid approach: group UI components by feature, and group Data/Domain components by type.
+
+```text
+lib/
+├── data/
+│   ├── models/         # API models
+│   ├── repositories/   # Repository implementations
+│   └── services/       # API clients, local storage wrappers
+├── domain/
+│   ├── models/         # Clean domain models
+│   └── use_cases/      # Optional business logic classes
+└── ui/
+    ├── core/           # Shared widgets, themes, typography
+    └── features/
+        └── [feature_name]/
+            ├── view_models/
+            └── views/
+```
+
+## Workflow: Implementing a New Feature
+
+Follow this sequential workflow when adding a new feature to the application. Copy the checklist to track progress.
+
+### Task Progress
+- [ ] **Step 1: Define Domain Models.** Create immutable data classes for the feature using `freezed` or `built_value`.
+- [ ] **Step 2: Implement Services.** Create or update Service classes to handle external API communication.
+- [ ] **Step 3: Implement Repositories.** Create the Repository to consume Services and return Domain Models.
+- [ ] **Step 4: Apply Conditional Logic (Domain Layer).**
+  - *If the feature requires complex data transformation or cross-repository logic:* Create a Use Case class.
+  - *If the feature is a simple CRUD operation:* Skip to Step 5.
+- [ ] **Step 5: Implement the ViewModel.** Create the ViewModel extending `ChangeNotifier`. Inject required Repositories/Use Cases. Expose immutable state and command methods.
+- [ ] **Step 6: Implement the View.** Create the UI widget. Use `ListenableBuilder` or `AnimatedBuilder` to listen to ViewModel changes.
+- [ ] **Step 7: Inject Dependencies.** Register the new Service, Repository, and ViewModel in the dependency injection container (e.g., `provider` or `get_it`).
+- [ ] **Step 8: Run Validator.** Execute unit tests for the ViewModel and Repository.
+  - *Feedback Loop:* Run tests -> Review failures -> Fix logic -> Re-run until passing.
+
+## Examples
+
+### Data Layer: Service and Repository
+
+```dart
+// 1. Service (Raw API interaction)
+class ApiClient {
+  Future<UserApiModel> fetchUser(String id) async {
+    // HTTP GET implementation...
+  }
+}
+
+// 2. Repository (Single source of truth, returns Domain Model)
+class UserRepository {
+  UserRepository({required ApiClient apiClient}) : _apiClient = apiClient;
+  
+  final ApiClient _apiClient;
+  User? _cachedUser;
+
+  Future<User> getUser(String id) async {
+    if (_cachedUser != null) return _cachedUser!;
+    
+    final apiModel = await _apiClient.fetchUser(id);
+    _cachedUser = User(id: apiModel.id, name: apiModel.fullName); // Transform to Domain Model
+    return _cachedUser!;
+  }
+}
+```
+
+### UI Layer: ViewModel and View
+
+```dart
+// 3. ViewModel (State management and presentation logic)
+class ProfileViewModel extends ChangeNotifier {
+  ProfileViewModel({required UserRepository userRepository}) 
+      : _userRepository = userRepository;
+
+  final UserRepository _userRepository;
+
+  User? _user;
+  User? get user => _user;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  Future<void> loadProfile(String id) async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      _user = await _userRepository.getUser(id);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}
+
+// 4. View (Dumb UI component)
+class ProfileView extends StatelessWidget {
+  const ProfileView({super.key, required this.viewModel});
+
+  final ProfileViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: viewModel,
+      builder: (context, _) {
+        if (viewModel.isLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        
+        final user = viewModel.user;
+        if (user == null) {
+          return const Center(child: Text('User not found'));
+        }
+
+        return Column(
+          children: [
+            Text(user.name),
+            ElevatedButton(
+              onPressed: () => viewModel.loadProfile(user.id),
+              child: const Text('Refresh'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+```

--- a/.agents/skills/flutter-build-responsive-layout/SKILL.md
+++ b/.agents/skills/flutter-build-responsive-layout/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: flutter-build-responsive-layout
+description: Use `LayoutBuilder`, `MediaQuery`, or `Expanded/Flexible` to create a layout that adapts to different screen sizes. Use when you need the UI to look good on both mobile and tablet/desktop form factors.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 20:17:40 GMT
+---
+# Implementing Adaptive Layouts
+
+## Contents
+- [Space Measurement Guidelines](#space-measurement-guidelines)
+- [Widget Sizing and Constraints](#widget-sizing-and-constraints)
+- [Device and Orientation Behaviors](#device-and-orientation-behaviors)
+- [Workflow: Constructing an Adaptive Layout](#workflow-constructing-an-adaptive-layout)
+- [Workflow: Optimizing for Large Screens](#workflow-optimizing-for-large-screens)
+- [Examples](#examples)
+
+## Space Measurement Guidelines
+Determine the available space accurately to ensure layouts adapt to the app window, not just the physical device.
+
+*   **Use `MediaQuery.sizeOf(context)`** to get the size of the entire app window.
+*   **Use `LayoutBuilder`** to make layout decisions based on the parent widget's allocated space. Evaluate `constraints.maxWidth` to determine the appropriate widget tree to return.
+*   **Do not use `MediaQuery.orientationOf` or `OrientationBuilder`** near the top of the widget tree to switch layouts. Device orientation does not accurately reflect the available app window space.
+*   **Do not check for hardware types** (e.g., "phone" vs. "tablet"). Flutter apps run in resizable windows, multi-window modes, and picture-in-picture. Base all layout decisions strictly on available window space.
+
+## Widget Sizing and Constraints
+Understand and apply Flutter's core layout rule: **Constraints go down. Sizes go up. Parent sets position.**
+
+*   **Distribute Space:** Use `Expanded` and `Flexible` within `Row`, `Column`, or `Flex` widgets.
+    *   Use `Expanded` to force a child to fill all remaining available space (equivalent to `Flexible` with `fit: FlexFit.tight` and a `flex` factor of 1.0).
+    *   Use `Flexible` to allow a child to size itself up to a specific limit while still expanding/contracting. Use the `flex` factor to define the ratio of space consumption among siblings.
+*   **Constrain Width:** Prevent widgets from consuming all horizontal space on large screens. Wrap widgets like `GridView` or `ListView` in a `ConstrainedBox` or `Container` and define a `maxWidth` in the `BoxConstraints`.
+*   **Lazy Rendering:** Always use `ListView.builder` or `GridView.builder` when rendering lists with an unknown or large number of items.
+
+## Device and Orientation Behaviors
+Ensure the app behaves correctly across all device form factors and input methods.
+
+*   **Do not lock screen orientation.** Locking orientation causes severe layout issues on foldable devices, often resulting in letterboxing (the app centered with black borders). Android large format tiers require both portrait and landscape support.
+*   **Fallback for Locked Orientation:** If business requirements strictly mandate a locked orientation, use the `Display API` to retrieve physical screen dimensions instead of `MediaQuery`. `MediaQuery` fails to receive the larger window size in compatibility modes.
+*   **Support Multiple Inputs:** Implement support for basic mice, trackpads, and keyboard shortcuts. Ensure touch targets are appropriately sized and keyboard navigation is accessible.
+
+## Workflow: Constructing an Adaptive Layout
+
+Follow this workflow to implement a layout that adapts to the available `BoxConstraints`.
+
+**Task Progress:**
+- [ ] Identify the target widget that requires adaptive behavior.
+- [ ] Wrap the widget tree in a `LayoutBuilder`.
+- [ ] Extract the `constraints.maxWidth` from the builder callback.
+- [ ] Define an adaptive breakpoint (e.g., `largeScreenMinWidth = 600`).
+- [ ] **If `maxWidth > largeScreenMinWidth`:** Return a large-screen layout (e.g., a `Row` placing a navigation sidebar and content area side-by-side).
+- [ ] **If `maxWidth <= largeScreenMinWidth`:** Return a small-screen layout (e.g., a `Column` or standard navigation-style approach).
+- [ ] Run validator -> resize the application window -> review layout transitions -> fix overflow errors.
+
+## Workflow: Optimizing for Large Screens
+
+Follow this workflow to prevent UI elements from stretching unnaturally on large displays.
+
+**Task Progress:**
+- [ ] Identify full-width components (e.g., `ListView`, text blocks, forms).
+- [ ] **If optimizing a list:** Convert `ListView.builder` to `GridView.builder` using `SliverGridDelegateWithMaxCrossAxisExtent` to automatically adjust column counts based on window size.
+- [ ] **If optimizing a form or text block:** Wrap the component in a `ConstrainedBox`.
+- [ ] Apply `BoxConstraints(maxWidth: [optimal_width])` to the `ConstrainedBox`.
+- [ ] Wrap the `ConstrainedBox` in a `Center` widget to keep the constrained content centered on large screens.
+- [ ] Run validator -> test on desktop/tablet target -> review horizontal stretching -> adjust `maxWidth` or grid extents.
+
+## Examples
+
+### Adaptive Layout using LayoutBuilder
+Demonstrates switching between a mobile and desktop layout based on available width.
+
+```dart
+import 'package:flutter/material.dart';
+
+const double largeScreenMinWidth = 600.0;
+
+class AdaptiveLayout extends StatelessWidget {
+  const AdaptiveLayout({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth > largeScreenMinWidth) {
+          return _buildLargeScreenLayout();
+        } else {
+          return _buildSmallScreenLayout();
+        }
+      },
+    );
+  }
+
+  Widget _buildLargeScreenLayout() {
+    return Row(
+      children: [
+        const SizedBox(width: 250, child: Placeholder(color: Colors.blue)),
+        const VerticalDivider(width: 1),
+        Expanded(child: const Placeholder(color: Colors.green)),
+      ],
+    );
+  }
+
+  Widget _buildSmallScreenLayout() {
+    return const Placeholder(color: Colors.green);
+  }
+}
+```
+
+### Constraining Width on Large Screens
+Demonstrates preventing a widget from consuming all horizontal space.
+
+```dart
+import 'package:flutter/material.dart';
+
+class ConstrainedContent extends StatelessWidget {
+  const ConstrainedContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: 800.0, // Maximum width for readability
+          ),
+          child: ListView.builder(
+            itemCount: 50,
+            itemBuilder: (context, index) {
+              return ListTile(
+                title: Text('Item $index'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+```

--- a/.agents/skills/flutter-fix-layout-issues/SKILL.md
+++ b/.agents/skills/flutter-fix-layout-issues/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: flutter-fix-layout-issues
+description: Fixes Flutter layout errors (overflows, unbounded constraints) using Dart and Flutter MCP tools. Use when addressing "RenderFlex overflowed", "Vertical viewport was given unbounded height", or similar layout issues.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 19:45:59 GMT
+---
+# Resolving Flutter Layout Errors
+
+## Contents
+- [Constraint Violation Diagnostics](#constraint-violation-diagnostics)
+- [Layout Error Resolution Workflow](#layout-error-resolution-workflow)
+- [Examples](#examples)
+
+## Constraint Violation Diagnostics
+
+Flutter layout operates on a strict rule: **Constraints go down. Sizes go up. Parent sets position.** Layout errors occur when this negotiation fails, typically due to unbounded constraints or unconstrained children. 
+
+Diagnose layout failures using the following error signatures:
+
+*   **"Vertical viewport was given unbounded height"**: Triggered when a scrollable widget (`ListView`, `GridView`) is placed inside an unconstrained vertical parent (`Column`). The parent provides infinite height, and the child attempts to expand infinitely.
+*   **"An InputDecorator...cannot have an unbounded width"**: Triggered when a `TextField` or `TextFormField` is placed inside an unconstrained horizontal parent (`Row`). The text field attempts to determine its width based on infinite available space.
+*   **"RenderFlex overflowed"**: Triggered when a child of a `Row` or `Column` requests a size larger than the parent's allocated constraints. Visually indicated by yellow and black warning stripes.
+*   **"Incorrect use of ParentData widget"**: Triggered when a `ParentDataWidget` is not a direct descendant of its required ancestor. (e.g., `Expanded` outside a `Flex`, `Positioned` outside a `Stack`).
+*   **"RenderBox was not laid out"**: A cascading side-effect error. Ignore this and look further up the stack trace for the primary constraint violation (usually an unbounded height/width error).
+
+## Layout Error Resolution Workflow
+
+Copy and use this checklist to systematically resolve layout constraint violations.
+
+### Task Progress
+- [ ] Run the application in debug mode to capture the exact layout exception in the console.
+- [ ] Identify the primary error message (ignore cascading "RenderBox was not laid out" errors).
+- [ ] Apply the conditional fix based on the specific error type:
+  - **If "Vertical viewport was given unbounded height"**: Wrap the scrollable child (`ListView`, `GridView`) in an `Expanded` widget to consume remaining space, or wrap it in a `SizedBox` to provide an absolute height constraint.
+  - **If "An InputDecorator...cannot have an unbounded width"**: Wrap the `TextField` or `TextFormField` in an `Expanded` or `Flexible` widget.
+  - **If "RenderFlex overflowed"**: Constrain the overflowing child by wrapping it in an `Expanded` widget (to force it to fit) or a `Flexible` widget (to allow it to be smaller than the allocated space).
+  - **If "Incorrect use of ParentData widget"**: Move the `ParentDataWidget` to be a direct child of its required parent. Ensure `Expanded`/`Flexible` are direct children of `Row`/`Column`/`Flex`. Ensure `Positioned` is a direct child of `Stack`.
+- [ ] Execute Flutter hot reload.
+- [ ] Run validator -> review errors -> fix: Inspect the UI to verify the red/grey error screen or yellow/black overflow stripes are resolved. If new layout errors appear, repeat the workflow.
+
+## Examples
+
+### Fixing Unbounded Height (ListView in Column)
+
+**Input (Error State):**
+```dart
+// Throws "Vertical viewport was given unbounded height"
+Column(
+  children: <Widget>[
+    const Text('Header'),
+    ListView(
+      children: const <Widget>[
+        ListTile(title: Text('Item 1')),
+        ListTile(title: Text('Item 2')),
+      ],
+    ),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap ListView in Expanded to constrain its height to the remaining Column space
+Column(
+  children: <Widget>[
+    const Text('Header'),
+    Expanded(
+      child: ListView(
+        children: const <Widget>[
+          ListTile(title: Text('Item 1')),
+          ListTile(title: Text('Item 2')),
+        ],
+      ),
+    ),
+  ],
+)
+```
+
+### Fixing Unbounded Width (TextField in Row)
+
+**Input (Error State):**
+```dart
+// Throws "An InputDecorator...cannot have an unbounded width"
+Row(
+  children: [
+    const Icon(Icons.search),
+    TextField(), 
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap TextField in Expanded to constrain its width to the remaining Row space
+Row(
+  children: [
+    const Icon(Icons.search),
+    Expanded(
+      child: TextField(),
+    ),
+  ],
+)
+```
+
+### Fixing RenderFlex Overflow
+
+**Input (Error State):**
+```dart
+// Throws "A RenderFlex overflowed by X pixels on the right"
+Row(
+  children: [
+    const Icon(Icons.info),
+    const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap the Text widget in Expanded to force it to wrap within the available constraints
+Row(
+  children: [
+    const Icon(Icons.info),
+    Expanded(
+      child: const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
+    ),
+  ],
+)
+```

--- a/.agents/skills/flutter-implement-json-serialization/SKILL.md
+++ b/.agents/skills/flutter-implement-json-serialization/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: flutter-implement-json-serialization
+description: Create model classes with `fromJson` and `toJson` methods using `dart:convert`. Use when manually mapping JSON keys to class properties for simple data structures.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 21:44:50 GMT
+---
+# Serializing JSON Manually in Flutter
+
+## Contents
+- [Core Guidelines](#core-guidelines)
+- [Workflow: Implementing a Serializable Model](#workflow-implementing-a-serializable-model)
+- [Workflow: Fetching and Parsing JSON](#workflow-fetching-and-parsing-json)
+- [Examples](#examples)
+
+## Core Guidelines
+
+- **Import `dart:convert`**: Utilize Flutter's built-in `dart:convert` library for manual JSON encoding (`jsonEncode`) and decoding (`jsonDecode`).
+- **Enforce Type Safety**: Always cast the `dynamic` result of `jsonDecode()` to the expected type, typically `Map<String, dynamic>` for objects or `List<dynamic>` for arrays.
+- **Encapsulate Serialization Logic**: Define plain model classes containing properties corresponding to the JSON structure. Implement a `fromJson` factory constructor and a `toJson` method within the model.
+- **Handle Background Parsing**: If parsing large JSON documents (execution time > 16ms), offload the parsing logic to a separate isolate using Flutter's `compute()` function to prevent UI jank.
+- **Throw Exceptions on Failure**: When handling HTTP responses, throw an exception if the status code is not successful (e.g., not 200 OK or 201 Created). Do not return `null`.
+
+## Workflow: Implementing a Serializable Model
+
+Use this checklist to implement manual JSON serialization for a data model.
+
+**Task Progress:**
+- [ ] Define the plain model class with `final` properties.
+- [ ] Implement the `factory Model.fromJson(Map<String, dynamic> json)` constructor.
+- [ ] Implement the `Map<String, dynamic> toJson()` method.
+- [ ] Write unit tests for both serialization methods.
+- [ ] Run validator -> review type mismatch errors -> fix casting logic.
+
+1. **Define the Model**: Create a class with properties matching the JSON keys.
+2. **Implement `fromJson`**: Extract values from the `Map` and cast them to the appropriate Dart types. Use pattern matching or explicit casting.
+3. **Implement `toJson`**: Return a `Map<String, dynamic>` mapping the class properties back to their JSON string keys.
+4. **Validate**: Execute unit tests to ensure type safety, autocompletion, and compile-time exception handling function correctly.
+
+## Workflow: Fetching and Parsing JSON
+
+Use this conditional workflow when retrieving and parsing JSON from a network request.
+
+**Task Progress:**
+- [ ] Execute the HTTP request.
+- [ ] Validate the response status code.
+- [ ] Determine parsing strategy (Synchronous vs. Isolate).
+- [ ] Decode and map the JSON to the model.
+
+1. **Execute Request**: Use the `http` package to perform the network call.
+2. **Validate Response**: 
+   - If `response.statusCode == 200` (or 201 for POST), proceed to parsing.
+   - If the status code indicates failure, throw an `Exception`.
+3. **Determine Parsing Strategy**:
+   - If parsing a **small payload** (e.g., a single object), parse synchronously on the main thread.
+   - If parsing a **large payload** (e.g., an array of thousands of objects), use `compute(parseFunction, response.body)` to parse in a background isolate.
+4. **Decode and Map**: Pass the decoded JSON to your model's `fromJson` constructor.
+
+## Examples
+
+### High-Fidelity Model Implementation
+
+```dart
+import 'dart:convert';
+
+class User {
+  final int id;
+  final String name;
+  final String email;
+
+  const User({
+    required this.id,
+    required this.name,
+    required this.email,
+  });
+
+  // Factory constructor for deserialization
+  factory User.fromJson(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'id': int id,
+        'name': String name,
+        'email': String email,
+      } => 
+        User(
+          id: id,
+          name: name,
+          email: email,
+        ),
+      _ => throw const FormatException('Failed to load User.'),
+    };
+  }
+
+  // Method for serialization
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'email': email,
+    };
+  }
+}
+```
+
+### Synchronous Parsing (Small Payload)
+
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<User> fetchUser(http.Client client, int userId) async {
+  final response = await client.get(
+    Uri.parse('https://api.example.com/users/$userId'),
+    headers: {'Accept': 'application/json'},
+  );
+
+  if (response.statusCode == 200) {
+    // Decode returns dynamic, cast to Map<String, dynamic>
+    final Map<String, dynamic> jsonMap = jsonDecode(response.body) as Map<String, dynamic>;
+    return User.fromJson(jsonMap);
+  } else {
+    throw Exception('Failed to load user');
+  }
+}
+```
+
+### Background Parsing (Large Payload)
+
+```dart
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+// Top-level function required for compute()
+List<User> parseUsers(String responseBody) {
+  final parsed = (jsonDecode(responseBody) as List<dynamic>).cast<Map<String, dynamic>>();
+  return parsed.map<User>((json) => User.fromJson(json)).toList();
+}
+
+Future<List<User>> fetchUsers(http.Client client) async {
+  final response = await client.get(
+    Uri.parse('https://api.example.com/users'),
+    headers: {'Accept': 'application/json'},
+  );
+
+  if (response.statusCode == 200) {
+    // Offload expensive parsing to a background isolate
+    return compute(parseUsers, response.body);
+  } else {
+    throw Exception('Failed to load users');
+  }
+}
+```

--- a/.agents/skills/flutter-setup-declarative-routing/SKILL.md
+++ b/.agents/skills/flutter-setup-declarative-routing/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: flutter-setup-declarative-routing
+description: Configure `MaterialApp.router` using a package like `go_router` for advanced URL-based navigation. Use when developing web applications or mobile apps that require specific deep linking and browser history support.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 21:08:03 GMT
+---
+# Implementing Routing and Deep Linking
+
+## Contents
+- [Core Concepts](#core-concepts)
+- [Workflow: Initializing the Application and Router](#workflow-initializing-the-application-and-router)
+- [Workflow: Configuring Platform Deep Linking](#workflow-configuring-platform-deep-linking)
+- [Workflow: Implementing Nested Navigation](#workflow-implementing-nested-navigation)
+- [Examples](#examples)
+
+## Core Concepts
+
+Use the `go_router` package for declarative routing in Flutter. It provides a robust API for complex routing scenarios, deep linking, and nested navigation. 
+
+- **GoRouter**: The central configuration object defining the application's route tree.
+- **GoRoute**: A standard route mapping a URL path to a Flutter screen.
+- **ShellRoute / StatefulShellRoute**: Wraps child routes in a persistent UI shell (e.g., a `BottomNavigationBar`). `StatefulShellRoute` maintains the state of parallel navigation branches.
+- **Path URL Strategy**: Removes the default `#` fragment from web URLs, essential for clean deep linking across platforms.
+
+## Workflow: Initializing the Application and Router
+
+Follow this workflow to bootstrap a new Flutter application with `go_router` and configure the root routing mechanism.
+
+### Task Progress
+- [ ] Create the Flutter application.
+- [ ] Add the `go_router` dependency.
+- [ ] Configure the URL strategy for web/deep linking.
+- [ ] Implement the `GoRouter` configuration.
+- [ ] Bind the router to `MaterialApp.router`.
+
+### 1. Scaffold the Application
+Run the following commands to create the app and add the required routing package:
+```bash
+flutter create <app-name>
+cd <app-name>
+flutter pub add go_router
+```
+
+### 2. Configure the Router
+Define a top-level `GoRouter` instance. Handle authentication or state-based routing using the `redirect` parameter.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
+
+void main() {
+  // Use path URL strategy to remove the '#' from web URLs
+  usePathUrlStrategy();
+  runApp(const MyApp());
+}
+
+final GoRouter _router = GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomeScreen(),
+      routes: [
+        GoRoute(
+          path: 'details/:id',
+          builder: (context, state) => DetailsScreen(id: state.pathParameters['id']!),
+        ),
+      ],
+    ),
+  ],
+  errorBuilder: (context, state) => ErrorScreen(error: state.error),
+);
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routerConfig: _router,
+      title: 'Routing App',
+    );
+  }
+}
+```
+
+## Workflow: Configuring Platform Deep Linking
+
+Configure the native platforms to intercept specific URLs and route them into the Flutter application.
+
+### Task Progress
+- [ ] Determine target platforms (iOS, Android, or both).
+- [ ] Apply conditional configuration for Android (Manifest + Asset Links).
+- [ ] Apply conditional configuration for iOS (Plist + Entitlements + AASA).
+- [ ] Run validator -> review errors -> fix.
+
+### If configuring for Android:
+1. **Modify `AndroidManifest.xml`**: Add the intent filter inside the `<activity>` tag for `.MainActivity`.
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="http" android:host="yourdomain.com" />
+    <data android:scheme="https" />
+</intent-filter>
+```
+2. **Host `assetlinks.json`**: Serve the following JSON at `https://yourdomain.com/.well-known/assetlinks.json`.
+```json
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "com.yourcompany.yourapp",
+    "sha256_cert_fingerprints": ["YOUR_SHA256_FINGERPRINT"]
+  }
+}]
+```
+
+### If configuring for iOS:
+1. **Modify `Info.plist`**: Opt-in to Flutter's default deep link handler. 
+*Note: If using a third-party deep linking plugin (e.g., `app_links`), set this to `NO` to prevent conflicts.*
+```xml
+<key>FlutterDeepLinkingEnabled</key>
+<true/>
+```
+2. **Modify `Runner.entitlements`**: Add the associated domain.
+```xml
+<key>com.apple.developer.associated-domains</key>
+<array>
+  <string>applinks:yourdomain.com</string>
+</array>
+```
+3. **Host `apple-app-site-association`**: Serve the following JSON (without a `.json` extension) at `https://yourdomain.com/.well-known/apple-app-site-association`.
+```json
+{
+  "applinks": {
+    "apps": [],
+    "details": [{
+      "appIDs": ["TEAM_ID.com.yourcompany.yourapp"],
+      "paths": ["*"],
+      "components": [{"/": "/*"}]
+    }]
+  }
+}
+```
+
+### Validation Loop
+Run validator -> review errors -> fix.
+- **Android**: Test using ADB.
+  ```bash
+  adb shell 'am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://yourdomain.com/details/123"' com.yourcompany.yourapp
+  ```
+- **iOS**: Test using `xcrun` on a booted simulator.
+  ```bash
+  xcrun simctl openurl booted https://yourdomain.com/details/123
+  ```
+
+## Workflow: Implementing Nested Navigation
+
+Use `StatefulShellRoute` to implement persistent UI shells (like a bottom navigation bar) that maintain the state of their child routes.
+
+### Task Progress
+- [ ] Define `StatefulShellRoute.indexedStack` in the `GoRouter` configuration.
+- [ ] Create `StatefulShellBranch` instances for each navigation tab.
+- [ ] Implement the shell widget using `StatefulNavigationShell`.
+
+```dart
+final GoRouter _router = GoRouter(
+  initialLocation: '/home',
+  routes: [
+    StatefulShellRoute.indexedStack(
+      builder: (context, state, navigationShell) {
+        return ScaffoldWithNavBar(navigationShell: navigationShell);
+      },
+      branches: [
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/home',
+              builder: (context, state) => const HomeScreen(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/settings',
+              builder: (context, state) => const SettingsScreen(),
+            ),
+          ],
+        ),
+      ],
+    ),
+  ],
+);
+```
+
+## Examples
+
+### High-Fidelity Shell Widget Implementation
+Implement the UI shell that consumes the `StatefulNavigationShell` to handle branch switching.
+
+```dart
+class ScaffoldWithNavBar extends StatelessWidget {
+  const ScaffoldWithNavBar({
+    required this.navigationShell,
+    super.key,
+  });
+
+  final StatefulNavigationShell navigationShell;
+
+  void _goBranch(int index) {
+    navigationShell.goBranch(
+      index,
+      // Support navigating to the initial location when tapping the active tab.
+      initialLocation: index == navigationShell.currentIndex,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: navigationShell,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: navigationShell.currentIndex,
+        onDestinationSelected: _goBranch,
+        destinations: const [
+          NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+          NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  }
+}
+```
+
+### Programmatic Navigation
+Use the `context.go()` and `context.push()` extension methods provided by `go_router`.
+
+```dart
+// Replaces the current route stack with the target route (Declarative)
+context.go('/details/123');
+
+// Pushes the target route onto the existing stack (Imperative)
+context.push('/details/123');
+
+// Navigates using a named route and path parameters
+context.goNamed('details', pathParameters: {'id': '123'});
+
+// Pops the current route
+context.pop();
+```

--- a/.agents/skills/flutter-setup-localization/SKILL.md
+++ b/.agents/skills/flutter-setup-localization/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: flutter-setup-localization
+description: Add `flutter_localizations` and `intl` dependencies, enable "generate true" in `pubspec.yaml`, and create an `l10n.yaml` configuration file. Use when initializing localization support for a new Flutter project.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 21:27:35 GMT
+---
+# Internationalizing Flutter Applications
+
+## Contents
+- [Core Concepts](#core-concepts)
+- [Setup Workflow](#setup-workflow)
+- [Implementation Workflow](#implementation-workflow)
+- [Advanced Formatting](#advanced-formatting)
+- [Examples](#examples)
+
+## Core Concepts
+Flutter handles internationalization (i18n) and localization (l10n) via the `flutter_localizations` and `intl` packages. The standard approach uses App Resource Bundle (`.arb`) files to define localized strings, which are then compiled into a generated `AppLocalizations` class for type-safe access within the widget tree.
+
+## Setup Workflow
+
+Copy and track this checklist when initializing internationalization in a Flutter project:
+
+- [ ] **Task Progress**
+  - [ ] 1. Add dependencies to `pubspec.yaml`.
+  - [ ] 2. Enable the `generate` flag.
+  - [ ] 3. Create the `l10n.yaml` configuration file.
+  - [ ] 4. Configure `MaterialApp` or `CupertinoApp`.
+
+### 1. Add Dependencies
+Add the required localization packages to the project. Execute the following commands in the terminal:
+```bash
+flutter pub add flutter_localizations --sdk=flutter
+flutter pub add intl:any
+```
+
+Verify your `pubspec.yaml` includes the following under `dependencies`:
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: any
+```
+
+### 2. Enable Code Generation
+Open `pubspec.yaml` and enable the `generate` flag within the `flutter` section to automate localization tasks:
+```yaml
+flutter:
+  generate: true
+```
+
+### 3. Create Configuration File
+Create a new file named `l10n.yaml` in the root directory of the Flutter project. Define the input directory, template file, and output file:
+```yaml
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+synthetic-package: true
+```
+
+### 4. Configure the App Entry Point
+Import the generated localizations and the `flutter_localizations` library in your `main.dart`. Inject the delegates and supported locales into your `MaterialApp` or `CupertinoApp`.
+
+```dart
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // Adjust path if synthetic-package is false
+
+// ... inside build method
+return MaterialApp(
+  localizationsDelegates: const [
+    AppLocalizations.delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ],
+  supportedLocales: const [
+    Locale('en'), // English
+    Locale('es'), // Spanish
+  ],
+  home: const MyHomePage(),
+);
+```
+
+## Implementation Workflow
+
+Follow this workflow when adding or modifying localized content.
+
+### 1. Define ARB Files
+*   **If creating NEW content:** Add the base string to the template file (`lib/l10n/app_en.arb`). Include a description for context.
+*   **If EDITING existing content:** Locate the key in all supported `.arb` files and update the values.
+
+```json
+{
+  "helloWorld": "Hello World!",
+  "@helloWorld": {
+    "description": "The conventional newborn programmer greeting"
+  }
+}
+```
+
+Create corresponding files for other locales (e.g., `app_es.arb`):
+```json
+{
+  "helloWorld": "¡Hola Mundo!"
+}
+```
+
+### 2. Generate Localization Classes
+Run the following command to trigger code generation:
+```bash
+flutter pub get
+```
+*Feedback Loop:* Run validator -> review terminal output for ARB syntax errors -> fix missing commas or mismatched placeholders -> re-run `flutter pub get`.
+
+### 3. Consume Localized Strings
+Access the localized strings in your widget tree using `AppLocalizations.of(context)`. Ensure the widget calling this is a descendant of `MaterialApp`.
+
+```dart
+Text(AppLocalizations.of(context)!.helloWorld)
+```
+
+## Advanced Formatting
+
+Use placeholders for dynamic data, plurals, and conditional selects.
+
+### Placeholders
+Define parameters within curly braces and specify their type in the metadata object.
+```json
+"hello": "Hello {userName}",
+"@hello": {
+  "description": "A message with a single parameter",
+  "placeholders": {
+    "userName": {
+      "type": "String",
+      "example": "Bob"
+    }
+  }
+}
+```
+
+### Plurals
+Use the `plural` syntax to handle quantity-based string variations. The `other` case is mandatory.
+```json
+"nWombats": "{count, plural, =0{no wombats} =1{1 wombat} other{{count} wombats}}",
+"@nWombats": {
+  "description": "A plural message",
+  "placeholders": {
+    "count": {
+      "type": "num",
+      "format": "compact"
+    }
+  }
+}
+```
+
+### Selects
+Use the `select` syntax for conditional strings, such as gendered text.
+```json
+"pronoun": "{gender, select, male{he} female{she} other{they}}",
+"@pronoun": {
+  "description": "A gendered message",
+  "placeholders": {
+    "gender": {
+      "type": "String"
+    }
+  }
+}
+```
+
+## Examples
+
+### Complete `l10n.yaml`
+```yaml
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+synthetic-package: true
+use-escaping: true
+```
+
+### Complete Widget Implementation
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class GreetingWidget extends StatelessWidget {
+  final String userName;
+  final int notificationCount;
+
+  const GreetingWidget({
+    super.key, 
+    required this.userName, 
+    required this.notificationCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Column(
+      children: [
+        Text(l10n.hello(userName)),
+        Text(l10n.nWombats(notificationCount)),
+      ],
+    );
+  }
+}
+```

--- a/.agents/skills/flutter-use-http-package/SKILL.md
+++ b/.agents/skills/flutter-use-http-package/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: flutter-use-http-package
+description: Use the `http` package to execute GET, POST, PUT, or DELETE requests. Use when you need to fetch from or send data to a REST API.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 21:36:42 GMT
+---
+# Implementing Flutter Networking
+
+## Contents
+- [Configuration & Permissions](#configuration--permissions)
+- [Request Execution & Response Handling](#request-execution--response-handling)
+- [Background Parsing](#background-parsing)
+- [Workflow: Executing Network Operations](#workflow-executing-network-operations)
+- [Examples](#examples)
+
+## Configuration & Permissions
+
+Configure the environment and platform-specific permissions required for network access.
+
+1. Add the `http` package dependency via the terminal:
+   ```bash
+   flutter pub add http
+   ```
+2. Import the package in your Dart files:
+   ```dart
+   import 'package:http/http.dart' as http;
+   ```
+3. Configure Android permissions by adding the Internet permission to `android/app/src/main/AndroidManifest.xml`:
+   ```xml
+   <uses-permission android:name="android.permission.INTERNET" />
+   ```
+4. Configure macOS entitlements by adding the network client key to both `macos/Runner/DebugProfile.entitlements` and `macos/Runner/Release.entitlements`:
+   ```xml
+   <key>com.apple.security.network.client</key>
+   <true/>
+   ```
+
+## Request Execution & Response Handling
+
+Execute HTTP operations and map responses to strongly typed Dart objects.
+
+*   **URIs:** Always parse URL strings using `Uri.parse('your_url')`.
+*   **Headers:** Inject authorization and content-type headers via the `headers` parameter map. Use `HttpHeaders.authorizationHeader` for auth tokens.
+*   **Payloads:** For POST and PUT requests, encode the body using `jsonEncode()` from `dart:convert`.
+*   **Status Validation:** Evaluate `response.statusCode`. Treat `200 OK` (GET/PUT/DELETE) and `201 CREATED` (POST) as success. 
+*   **Error Handling:** Throw explicit exceptions for non-success status codes. Never return `null` on failure, as this prevents `FutureBuilder` from triggering its error state and causes infinite loading indicators.
+*   **Deserialization:** Parse the raw string using `jsonDecode(response.body)` and map it to a custom Dart object using a factory constructor (e.g., `fromJson`).
+
+## Background Parsing
+
+Offload expensive JSON parsing to a separate Isolate to prevent UI jank (frame drops).
+
+*   Import `package:flutter/foundation.dart`.
+*   Use the `compute()` function to run the parsing logic in a background isolate.
+*   Ensure the parsing function passed to `compute()` is a top-level function or a static method, as closures or instance methods cannot be passed across isolates.
+
+## Workflow: Executing Network Operations
+
+Use the following checklist to implement and validate network operations.
+
+**Task Progress:**
+- [ ] 1. Define the strongly typed Dart model with a `fromJson` factory constructor.
+- [ ] 2. Implement the network request method returning a `Future<Model>`.
+- [ ] 3. Apply conditional logic based on the operation type:
+  - **If fetching data (GET):** Append query parameters to the URI.
+  - **If mutating data (POST/PUT):** Set `'Content-Type': 'application/json; charset=UTF-8'` and attach the `jsonEncode` body.
+  - **If deleting data (DELETE):** Return an empty model instance on success (`200 OK`).
+- [ ] 4. Validate the `statusCode` and throw an `Exception` on failure.
+- [ ] 5. Integrate the `Future` into the UI using `FutureBuilder`.
+- [ ] 6. Handle `snapshot.hasData`, `snapshot.hasError`, and default to a `CircularProgressIndicator`.
+- [ ] 7. **Feedback Loop:** Run the app -> trigger the network request -> review console for unhandled exceptions -> fix parsing or permission errors.
+
+## Examples
+
+### High-Fidelity Implementation: Fetching and Parsing in the Background
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+// 1. Top-level parsing function for Isolate
+List<Photo> parsePhotos(String responseBody) {
+  final parsed = (jsonDecode(responseBody) as List<Object?>)
+      .cast<Map<String, Object?>>();
+  return parsed.map<Photo>(Photo.fromJson).toList();
+}
+
+// 2. Network execution with background parsing
+Future<List<Photo>> fetchPhotos() async {
+  final response = await http.get(
+    Uri.parse('https://jsonplaceholder.typicode.com/photos'),
+    headers: {
+      HttpHeaders.authorizationHeader: 'Bearer your_token_here',
+      HttpHeaders.acceptHeader: 'application/json',
+    },
+  );
+
+  if (response.statusCode == 200) {
+    // Offload heavy parsing to a background isolate
+    return compute(parsePhotos, response.body);
+  } else {
+    throw Exception('Failed to load photos. Status: ${response.statusCode}');
+  }
+}
+
+// 3. Strongly typed model
+class Photo {
+  final int id;
+  final String title;
+  final String thumbnailUrl;
+
+  const Photo({
+    required this.id,
+    required this.title,
+    required this.thumbnailUrl,
+  });
+
+  factory Photo.fromJson(Map<String, dynamic> json) {
+    return Photo(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      thumbnailUrl: json['thumbnailUrl'] as String,
+    );
+  }
+}
+
+// 4. UI Integration
+class PhotoGallery extends StatefulWidget {
+  const PhotoGallery({super.key});
+
+  @override
+  State<PhotoGallery> createState() => _PhotoGalleryState();
+}
+
+class _PhotoGalleryState extends State<PhotoGallery> {
+  late Future<List<Photo>> _futurePhotos;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize Future once to prevent re-fetching on rebuilds
+    _futurePhotos = fetchPhotos();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Photo>>(
+      future: _futurePhotos,
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          final photos = snapshot.data!;
+          return ListView.builder(
+            itemCount: photos.length,
+            itemBuilder: (context, index) => ListTile(
+              leading: Image.network(photos[index].thumbnailUrl),
+              title: Text(photos[index].title),
+            ),
+          );
+        } else if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
+        
+        // Default loading state
+        return const Center(child: CircularProgressIndicator());
+      },
+    );
+  }
+}
+```

--- a/lib/board/providers/board_home_provider.dart
+++ b/lib/board/providers/board_home_provider.dart
@@ -1,17 +1,9 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:smarthome/board/model/models.dart';
-import 'package:smarthome/board/repository/board_repository.dart';
 import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 
 part 'board_home_provider.g.dart';
-
-/// Board repository provider
-@Riverpod(keepAlive: true)
-BoardRepository boardRepository(Ref ref) {
-  final graphqlApiClient = ref.watch(graphQLApiClientProvider);
-  return BoardRepository(graphqlApiClient: graphqlApiClient);
-}
 
 /// Board home state
 class BoardHomeState {
@@ -78,6 +70,7 @@ class BoardHome extends _$BoardHome {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: BoardHomeStatus.success,
           topics: state.topics + results.item1,
@@ -86,6 +79,7 @@ class BoardHome extends _$BoardHome {
       } else {
         // 其他情况根据设置看是否需要打开缓存，并获取第一页
         final results = await boardRepository.topics(cache: cache);
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: BoardHomeStatus.success,
           topics: results.item1,
@@ -93,6 +87,7 @@ class BoardHome extends _$BoardHome {
         );
       }
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: BoardHomeStatus.failure,
         errorMessage: e.message,

--- a/lib/board/providers/board_home_provider.g.dart
+++ b/lib/board/providers/board_home_provider.g.dart
@@ -8,53 +8,6 @@ part of 'board_home_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Board repository provider
-
-@ProviderFor(boardRepository)
-final boardRepositoryProvider = BoardRepositoryProvider._();
-
-/// Board repository provider
-
-final class BoardRepositoryProvider
-    extends
-        $FunctionalProvider<BoardRepository, BoardRepository, BoardRepository>
-    with $Provider<BoardRepository> {
-  /// Board repository provider
-  BoardRepositoryProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'boardRepositoryProvider',
-        isAutoDispose: false,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$boardRepositoryHash();
-
-  @$internal
-  @override
-  $ProviderElement<BoardRepository> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
-
-  @override
-  BoardRepository create(Ref ref) {
-    return boardRepository(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(BoardRepository value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<BoardRepository>(value),
-    );
-  }
-}
-
-String _$boardRepositoryHash() => r'a18f76f69296152aa04c5c28cff6f082c9e79665';
-
 /// Board home notifier
 
 @ProviderFor(BoardHome)
@@ -91,7 +44,7 @@ final class BoardHomeProvider
   }
 }
 
-String _$boardHomeHash() => r'a4b70e56447968920b3868502390e319d25d918e';
+String _$boardHomeHash() => r'f81d8af40f3b031c6360f118706b307065bf3fd3';
 
 /// Board home notifier
 

--- a/lib/board/providers/board_home_provider.g.dart
+++ b/lib/board/providers/board_home_provider.g.dart
@@ -11,7 +11,7 @@ part of 'board_home_provider.dart';
 /// Board repository provider
 
 @ProviderFor(boardRepository)
-const boardRepositoryProvider = BoardRepositoryProvider._();
+final boardRepositoryProvider = BoardRepositoryProvider._();
 
 /// Board repository provider
 
@@ -20,7 +20,7 @@ final class BoardRepositoryProvider
         $FunctionalProvider<BoardRepository, BoardRepository, BoardRepository>
     with $Provider<BoardRepository> {
   /// Board repository provider
-  const BoardRepositoryProvider._()
+  BoardRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -58,13 +58,13 @@ String _$boardRepositoryHash() => r'a18f76f69296152aa04c5c28cff6f082c9e79665';
 /// Board home notifier
 
 @ProviderFor(BoardHome)
-const boardHomeProvider = BoardHomeProvider._();
+final boardHomeProvider = BoardHomeProvider._();
 
 /// Board home notifier
 final class BoardHomeProvider
     extends $NotifierProvider<BoardHome, BoardHomeState> {
   /// Board home notifier
-  const BoardHomeProvider._()
+  BoardHomeProvider._()
     : super(
         from: null,
         argument: null,
@@ -100,7 +100,6 @@ abstract class _$BoardHome extends $Notifier<BoardHomeState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<BoardHomeState, BoardHomeState>;
     final element =
         ref.element
@@ -110,6 +109,6 @@ abstract class _$BoardHome extends $Notifier<BoardHomeState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/board/providers/comment_edit_provider.dart
+++ b/lib/board/providers/comment_edit_provider.dart
@@ -1,6 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:smarthome/board/model/board.dart';
-import 'package:smarthome/board/providers/providers.dart';
+import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 
 part 'comment_edit_provider.g.dart';

--- a/lib/board/providers/comment_edit_provider.g.dart
+++ b/lib/board/providers/comment_edit_provider.g.dart
@@ -11,13 +11,13 @@ part of 'comment_edit_provider.dart';
 /// Comment edit notifier
 
 @ProviderFor(CommentEdit)
-const commentEditProvider = CommentEditProvider._();
+final commentEditProvider = CommentEditProvider._();
 
 /// Comment edit notifier
 final class CommentEditProvider
     extends $NotifierProvider<CommentEdit, CommentEditState> {
   /// Comment edit notifier
-  const CommentEditProvider._()
+  CommentEditProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$CommentEdit extends $Notifier<CommentEditState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<CommentEditState, CommentEditState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$CommentEdit extends $Notifier<CommentEditState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/board/providers/topic_detail_provider.dart
+++ b/lib/board/providers/topic_detail_provider.dart
@@ -87,6 +87,7 @@ class TopicDetail extends _$TopicDetail {
         after: state.pageInfo.endCursor,
         cache: false,
       );
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: TopicDetailStatus.success,
         topic: results.item1,
@@ -94,6 +95,7 @@ class TopicDetail extends _$TopicDetail {
         pageInfo: state.pageInfo.copyWith(results.item3),
       );
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: TopicDetailStatus.failure,
         errorMessage: e.message,
@@ -119,6 +121,7 @@ class TopicDetail extends _$TopicDetail {
         cache: cache,
       );
 
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: TopicDetailStatus.success,
         topic: results.item1,
@@ -126,6 +129,7 @@ class TopicDetail extends _$TopicDetail {
         pageInfo: results.item3,
       );
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: TopicDetailStatus.failure,
         errorMessage: e.message,

--- a/lib/board/providers/topic_detail_provider.g.dart
+++ b/lib/board/providers/topic_detail_provider.g.dart
@@ -11,13 +11,13 @@ part of 'topic_detail_provider.dart';
 /// Topic detail notifier
 
 @ProviderFor(TopicDetail)
-const topicDetailProvider = TopicDetailFamily._();
+final topicDetailProvider = TopicDetailFamily._();
 
 /// Topic detail notifier
 final class TopicDetailProvider
     extends $NotifierProvider<TopicDetail, TopicDetailState> {
   /// Topic detail notifier
-  const TopicDetailProvider._({
+  TopicDetailProvider._({
     required TopicDetailFamily super.from,
     required String super.argument,
   }) : super(
@@ -74,7 +74,7 @@ final class TopicDetailFamily extends $Family
           TopicDetailState,
           String
         > {
-  const TopicDetailFamily._()
+  TopicDetailFamily._()
     : super(
         retry: null,
         name: r'topicDetailProvider',
@@ -102,7 +102,6 @@ abstract class _$TopicDetail extends $Notifier<TopicDetailState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(_$args);
     final ref = this.ref as $Ref<TopicDetailState, TopicDetailState>;
     final element =
         ref.element
@@ -112,6 +111,6 @@ abstract class _$TopicDetail extends $Notifier<TopicDetailState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/lib/board/providers/topic_detail_provider.g.dart
+++ b/lib/board/providers/topic_detail_provider.g.dart
@@ -61,7 +61,7 @@ final class TopicDetailProvider
   }
 }
 
-String _$topicDetailHash() => r'9bf29a94895dfb7bab588f212fbe514dd75ff9c1';
+String _$topicDetailHash() => r'f3bfc5e56fa6f99ad60a9352ccd73461a22e053e';
 
 /// Topic detail notifier
 

--- a/lib/board/providers/topic_edit_provider.dart
+++ b/lib/board/providers/topic_edit_provider.dart
@@ -1,6 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:smarthome/board/model/board.dart';
-import 'package:smarthome/board/providers/providers.dart';
+import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 
 part 'topic_edit_provider.g.dart';

--- a/lib/board/providers/topic_edit_provider.g.dart
+++ b/lib/board/providers/topic_edit_provider.g.dart
@@ -11,13 +11,13 @@ part of 'topic_edit_provider.dart';
 /// Topic edit notifier
 
 @ProviderFor(TopicEdit)
-const topicEditProvider = TopicEditProvider._();
+final topicEditProvider = TopicEditProvider._();
 
 /// Topic edit notifier
 final class TopicEditProvider
     extends $NotifierProvider<TopicEdit, TopicEditState> {
   /// Topic edit notifier
-  const TopicEditProvider._()
+  TopicEditProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$TopicEdit extends $Notifier<TopicEditState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<TopicEditState, TopicEditState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$TopicEdit extends $Notifier<TopicEditState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/core/providers/authentication_provider.g.dart
+++ b/lib/core/providers/authentication_provider.g.dart
@@ -11,13 +11,13 @@ part of 'authentication_provider.dart';
 /// Authentication Notifier
 
 @ProviderFor(Authentication)
-const authenticationProvider = AuthenticationProvider._();
+final authenticationProvider = AuthenticationProvider._();
 
 /// Authentication Notifier
 final class AuthenticationProvider
     extends $NotifierProvider<Authentication, AuthState> {
   /// Authentication Notifier
-  const AuthenticationProvider._()
+  AuthenticationProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$Authentication extends $Notifier<AuthState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<AuthState, AuthState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$Authentication extends $Notifier<AuthState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/core/providers/push_provider.g.dart
+++ b/lib/core/providers/push_provider.g.dart
@@ -11,12 +11,12 @@ part of 'push_provider.dart';
 /// Push Notifier
 
 @ProviderFor(Push)
-const pushProvider = PushProvider._();
+final pushProvider = PushProvider._();
 
 /// Push Notifier
 final class PushProvider extends $NotifierProvider<Push, PushInfo> {
   /// Push Notifier
-  const PushProvider._()
+  PushProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,7 +52,6 @@ abstract class _$Push extends $Notifier<PushInfo> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<PushInfo, PushInfo>;
     final element =
         ref.element
@@ -62,6 +61,6 @@ abstract class _$Push extends $Notifier<PushInfo> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/core/providers/repository_providers.g.dart
+++ b/lib/core/providers/repository_providers.g.dart
@@ -11,7 +11,7 @@ part of 'repository_providers.dart';
 /// Settings Repository Provider
 
 @ProviderFor(settingsRepository)
-const settingsRepositoryProvider = SettingsRepositoryProvider._();
+final settingsRepositoryProvider = SettingsRepositoryProvider._();
 
 /// Settings Repository Provider
 
@@ -24,7 +24,7 @@ final class SettingsRepositoryProvider
         >
     with $Provider<SettingsRepository> {
   /// Settings Repository Provider
-  const SettingsRepositoryProvider._()
+  SettingsRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -64,7 +64,7 @@ String _$settingsRepositoryHash() =>
 /// GraphQL API Client Provider
 
 @ProviderFor(graphQLApiClient)
-const graphQLApiClientProvider = GraphQLApiClientProvider._();
+final graphQLApiClientProvider = GraphQLApiClientProvider._();
 
 /// GraphQL API Client Provider
 
@@ -77,7 +77,7 @@ final class GraphQLApiClientProvider
         >
     with $Provider<GraphQLApiClient> {
   /// GraphQL API Client Provider
-  const GraphQLApiClientProvider._()
+  GraphQLApiClientProvider._()
     : super(
         from: null,
         argument: null,
@@ -115,7 +115,7 @@ String _$graphQLApiClientHash() => r'ff65460a423a64734cdbe5eb175cae3c0dbc294f';
 /// User Repository Provider
 
 @ProviderFor(userRepository)
-const userRepositoryProvider = UserRepositoryProvider._();
+final userRepositoryProvider = UserRepositoryProvider._();
 
 /// User Repository Provider
 
@@ -123,7 +123,7 @@ final class UserRepositoryProvider
     extends $FunctionalProvider<UserRepository, UserRepository, UserRepository>
     with $Provider<UserRepository> {
   /// User Repository Provider
-  const UserRepositoryProvider._()
+  UserRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -161,7 +161,7 @@ String _$userRepositoryHash() => r'c5ba3c4a194632b2f8b7c8c137baca58ce9560f4';
 /// Version Repository Provider
 
 @ProviderFor(versionRepository)
-const versionRepositoryProvider = VersionRepositoryProvider._();
+final versionRepositoryProvider = VersionRepositoryProvider._();
 
 /// Version Repository Provider
 
@@ -174,7 +174,7 @@ final class VersionRepositoryProvider
         >
     with $Provider<VersionRepository> {
   /// Version Repository Provider
-  const VersionRepositoryProvider._()
+  VersionRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -213,7 +213,7 @@ String _$versionRepositoryHash() => r'cc89033f8a11cd3d74c3833a521322b6baf5115d';
 /// Push Repository Provider
 
 @ProviderFor(pushRepository)
-const pushRepositoryProvider = PushRepositoryProvider._();
+final pushRepositoryProvider = PushRepositoryProvider._();
 
 /// Push Repository Provider
 
@@ -221,7 +221,7 @@ final class PushRepositoryProvider
     extends $FunctionalProvider<PushRepository, PushRepository, PushRepository>
     with $Provider<PushRepository> {
   /// Push Repository Provider
-  const PushRepositoryProvider._()
+  PushRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -259,7 +259,7 @@ String _$pushRepositoryHash() => r'14e0291438a8584623f11f841de42629655031e0';
 /// Storage Repository Provider
 
 @ProviderFor(storageRepository)
-const storageRepositoryProvider = StorageRepositoryProvider._();
+final storageRepositoryProvider = StorageRepositoryProvider._();
 
 /// Storage Repository Provider
 
@@ -272,7 +272,7 @@ final class StorageRepositoryProvider
         >
     with $Provider<StorageRepository> {
   /// Storage Repository Provider
-  const StorageRepositoryProvider._()
+  StorageRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -311,7 +311,7 @@ String _$storageRepositoryHash() => r'880dd2019f5c2dc18a86e8eab687f48d38627e8e';
 /// Board Repository Provider
 
 @ProviderFor(boardRepository)
-const boardRepositoryProvider = BoardRepositoryProvider._();
+final boardRepositoryProvider = BoardRepositoryProvider._();
 
 /// Board Repository Provider
 
@@ -320,7 +320,7 @@ final class BoardRepositoryProvider
         $FunctionalProvider<BoardRepository, BoardRepository, BoardRepository>
     with $Provider<BoardRepository> {
   /// Board Repository Provider
-  const BoardRepositoryProvider._()
+  BoardRepositoryProvider._()
     : super(
         from: null,
         argument: null,

--- a/lib/core/providers/settings_provider.g.dart
+++ b/lib/core/providers/settings_provider.g.dart
@@ -11,13 +11,13 @@ part of 'settings_provider.dart';
 /// Settings Notifier
 
 @ProviderFor(Settings)
-const settingsProvider = SettingsProvider._();
+final settingsProvider = SettingsProvider._();
 
 /// Settings Notifier
 final class SettingsProvider
     extends $NotifierProvider<Settings, SettingsState> {
   /// Settings Notifier
-  const SettingsProvider._()
+  SettingsProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$Settings extends $Notifier<SettingsState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<SettingsState, SettingsState>;
     final element =
         ref.element
@@ -63,14 +62,14 @@ abstract class _$Settings extends $Notifier<SettingsState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }
 
 /// App Config Provider - Must be overridden in bootstrap
 
 @ProviderFor(appConfig)
-const appConfigProvider = AppConfigProvider._();
+final appConfigProvider = AppConfigProvider._();
 
 /// App Config Provider - Must be overridden in bootstrap
 
@@ -78,7 +77,7 @@ final class AppConfigProvider
     extends $FunctionalProvider<AppConfig, AppConfig, AppConfig>
     with $Provider<AppConfig> {
   /// App Config Provider - Must be overridden in bootstrap
-  const AppConfigProvider._()
+  AppConfigProvider._()
     : super(
         from: null,
         argument: null,

--- a/lib/core/providers/tab_provider.g.dart
+++ b/lib/core/providers/tab_provider.g.dart
@@ -11,12 +11,12 @@ part of 'tab_provider.dart';
 /// Tab notifier - 管理底部导航栏的当前标签
 
 @ProviderFor(Tab)
-const tabProvider = TabProvider._();
+final tabProvider = TabProvider._();
 
 /// Tab notifier - 管理底部导航栏的当前标签
 final class TabProvider extends $NotifierProvider<Tab, AppTab?> {
   /// Tab notifier - 管理底部导航栏的当前标签
-  const TabProvider._()
+  TabProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,7 +52,6 @@ abstract class _$Tab extends $Notifier<AppTab?> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<AppTab?, AppTab?>;
     final element =
         ref.element
@@ -62,6 +61,6 @@ abstract class _$Tab extends $Notifier<AppTab?> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/core/providers/update_provider.g.dart
+++ b/lib/core/providers/update_provider.g.dart
@@ -11,12 +11,12 @@ part of 'update_provider.dart';
 /// Update Notifier
 
 @ProviderFor(Update)
-const updateProvider = UpdateProvider._();
+final updateProvider = UpdateProvider._();
 
 /// Update Notifier
 final class UpdateProvider extends $NotifierProvider<Update, UpdateInfo> {
   /// Update Notifier
-  const UpdateProvider._()
+  UpdateProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,7 +52,6 @@ abstract class _$Update extends $Notifier<UpdateInfo> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<UpdateInfo, UpdateInfo>;
     final element =
         ref.element
@@ -62,6 +61,6 @@ abstract class _$Update extends $Notifier<UpdateInfo> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/consumables_provider.dart
+++ b/lib/storage/providers/consumables_provider.dart
@@ -70,6 +70,7 @@ class Consumables extends _$Consumables {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: ConsumablesStatus.success,
           items: state.items + results.item1,
@@ -78,6 +79,7 @@ class Consumables extends _$Consumables {
       } else {
         // 其他情况根据设置看是否需要打开缓存，并获取第一页
         final results = await storageRepository.consumables(cache: cache);
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: ConsumablesStatus.success,
           items: results.item1,
@@ -85,6 +87,7 @@ class Consumables extends _$Consumables {
         );
       }
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: ConsumablesStatus.failure,
         errorMessage: e.message,

--- a/lib/storage/providers/consumables_provider.g.dart
+++ b/lib/storage/providers/consumables_provider.g.dart
@@ -11,13 +11,13 @@ part of 'consumables_provider.dart';
 /// Consumables notifier
 
 @ProviderFor(Consumables)
-const consumablesProvider = ConsumablesProvider._();
+final consumablesProvider = ConsumablesProvider._();
 
 /// Consumables notifier
 final class ConsumablesProvider
     extends $NotifierProvider<Consumables, ConsumablesState> {
   /// Consumables notifier
-  const ConsumablesProvider._()
+  ConsumablesProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$Consumables extends $Notifier<ConsumablesState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<ConsumablesState, ConsumablesState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$Consumables extends $Notifier<ConsumablesState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/consumables_provider.g.dart
+++ b/lib/storage/providers/consumables_provider.g.dart
@@ -44,7 +44,7 @@ final class ConsumablesProvider
   }
 }
 
-String _$consumablesHash() => r'70412e6b02e74665db7a273209278da4dbb03c1f';
+String _$consumablesHash() => r'16c302d1a6b0e9fd5252a4d2998fa7b001a75993';
 
 /// Consumables notifier
 

--- a/lib/storage/providers/item_detail_provider.g.dart
+++ b/lib/storage/providers/item_detail_provider.g.dart
@@ -11,13 +11,13 @@ part of 'item_detail_provider.dart';
 /// Item detail notifier
 
 @ProviderFor(ItemDetail)
-const itemDetailProvider = ItemDetailFamily._();
+final itemDetailProvider = ItemDetailFamily._();
 
 /// Item detail notifier
 final class ItemDetailProvider
     extends $AsyncNotifierProvider<ItemDetail, Item> {
   /// Item detail notifier
-  const ItemDetailProvider._({
+  ItemDetailProvider._({
     required ItemDetailFamily super.from,
     required String super.argument,
   }) : super(
@@ -66,7 +66,7 @@ final class ItemDetailFamily extends $Family
           FutureOr<Item>,
           String
         > {
-  const ItemDetailFamily._()
+  ItemDetailFamily._()
     : super(
         retry: null,
         name: r'itemDetailProvider',
@@ -94,7 +94,6 @@ abstract class _$ItemDetail extends $AsyncNotifier<Item> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(_$args);
     final ref = this.ref as $Ref<AsyncValue<Item>, Item>;
     final element =
         ref.element
@@ -104,6 +103,6 @@ abstract class _$ItemDetail extends $AsyncNotifier<Item> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/lib/storage/providers/item_edit_provider.g.dart
+++ b/lib/storage/providers/item_edit_provider.g.dart
@@ -11,13 +11,13 @@ part of 'item_edit_provider.dart';
 /// Item edit notifier
 
 @ProviderFor(ItemEdit)
-const itemEditProvider = ItemEditProvider._();
+final itemEditProvider = ItemEditProvider._();
 
 /// Item edit notifier
 final class ItemEditProvider
     extends $NotifierProvider<ItemEdit, ItemEditState> {
   /// Item edit notifier
-  const ItemEditProvider._()
+  ItemEditProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$ItemEdit extends $Notifier<ItemEditState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<ItemEditState, ItemEditState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$ItemEdit extends $Notifier<ItemEditState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/picture_edit_provider.g.dart
+++ b/lib/storage/providers/picture_edit_provider.g.dart
@@ -11,13 +11,13 @@ part of 'picture_edit_provider.dart';
 /// Picture edit notifier
 
 @ProviderFor(PictureEdit)
-const pictureEditProvider = PictureEditProvider._();
+final pictureEditProvider = PictureEditProvider._();
 
 /// Picture edit notifier
 final class PictureEditProvider
     extends $NotifierProvider<PictureEdit, PictureEditState> {
   /// Picture edit notifier
-  const PictureEditProvider._()
+  PictureEditProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$PictureEdit extends $Notifier<PictureEditState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<PictureEditState, PictureEditState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$PictureEdit extends $Notifier<PictureEditState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/picture_provider.g.dart
+++ b/lib/storage/providers/picture_provider.g.dart
@@ -11,13 +11,13 @@ part of 'picture_provider.dart';
 /// Picture notifier
 
 @ProviderFor(PictureNotifier)
-const pictureProvider = PictureNotifierFamily._();
+final pictureProvider = PictureNotifierFamily._();
 
 /// Picture notifier
 final class PictureNotifierProvider
     extends $AsyncNotifierProvider<PictureNotifier, Picture> {
   /// Picture notifier
-  const PictureNotifierProvider._({
+  PictureNotifierProvider._({
     required PictureNotifierFamily super.from,
     required String super.argument,
   }) : super(
@@ -66,7 +66,7 @@ final class PictureNotifierFamily extends $Family
           FutureOr<Picture>,
           String
         > {
-  const PictureNotifierFamily._()
+  PictureNotifierFamily._()
     : super(
         retry: null,
         name: r'pictureProvider',
@@ -94,7 +94,6 @@ abstract class _$PictureNotifier extends $AsyncNotifier<Picture> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(_$args);
     final ref = this.ref as $Ref<AsyncValue<Picture>, Picture>;
     final element =
         ref.element
@@ -104,6 +103,6 @@ abstract class _$PictureNotifier extends $AsyncNotifier<Picture> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/lib/storage/providers/recycle_bin_provider.dart
+++ b/lib/storage/providers/recycle_bin_provider.dart
@@ -70,6 +70,7 @@ class RecycleBin extends _$RecycleBin {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: RecycleBinStatus.success,
           items: state.items + results.item1,
@@ -78,6 +79,7 @@ class RecycleBin extends _$RecycleBin {
       } else {
         // 其他情况根据设置看是否需要打开缓存，并获取第一页
         final results = await storageRepository.deletedItems(cache: cache);
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: RecycleBinStatus.success,
           items: results.item1,
@@ -85,6 +87,7 @@ class RecycleBin extends _$RecycleBin {
         );
       }
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: RecycleBinStatus.failure,
         errorMessage: e.message,

--- a/lib/storage/providers/recycle_bin_provider.g.dart
+++ b/lib/storage/providers/recycle_bin_provider.g.dart
@@ -11,13 +11,13 @@ part of 'recycle_bin_provider.dart';
 /// RecycleBin notifier
 
 @ProviderFor(RecycleBin)
-const recycleBinProvider = RecycleBinProvider._();
+final recycleBinProvider = RecycleBinProvider._();
 
 /// RecycleBin notifier
 final class RecycleBinProvider
     extends $NotifierProvider<RecycleBin, RecycleBinState> {
   /// RecycleBin notifier
-  const RecycleBinProvider._()
+  RecycleBinProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$RecycleBin extends $Notifier<RecycleBinState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<RecycleBinState, RecycleBinState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$RecycleBin extends $Notifier<RecycleBinState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/recycle_bin_provider.g.dart
+++ b/lib/storage/providers/recycle_bin_provider.g.dart
@@ -44,7 +44,7 @@ final class RecycleBinProvider
   }
 }
 
-String _$recycleBinHash() => r'9fc8c86f97c9549bf74ce52b6674a40312b7d0b2';
+String _$recycleBinHash() => r'5d082b32359beb2745380e60ba3b7e926d155a13';
 
 /// RecycleBin notifier
 

--- a/lib/storage/providers/search_provider.dart
+++ b/lib/storage/providers/search_provider.dart
@@ -72,6 +72,7 @@ class Search extends _$Search {
         isDeleted: isDeleted,
         missingStorage: missingStorage,
       );
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: SearchStatus.success,
         items: results.item1,
@@ -79,6 +80,7 @@ class Search extends _$Search {
         term: key,
       );
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: SearchStatus.failure,
         errorMessage: e.message,

--- a/lib/storage/providers/search_provider.g.dart
+++ b/lib/storage/providers/search_provider.g.dart
@@ -11,12 +11,12 @@ part of 'search_provider.dart';
 /// Search notifier
 
 @ProviderFor(Search)
-const searchProvider = SearchProvider._();
+final searchProvider = SearchProvider._();
 
 /// Search notifier
 final class SearchProvider extends $NotifierProvider<Search, SearchState> {
   /// Search notifier
-  const SearchProvider._()
+  SearchProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,7 +52,6 @@ abstract class _$Search extends $Notifier<SearchState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<SearchState, SearchState>;
     final element =
         ref.element
@@ -62,6 +61,6 @@ abstract class _$Search extends $Notifier<SearchState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/search_provider.g.dart
+++ b/lib/storage/providers/search_provider.g.dart
@@ -43,7 +43,7 @@ final class SearchProvider extends $NotifierProvider<Search, SearchState> {
   }
 }
 
-String _$searchHash() => r'51339dff12180c6309c3c86c77b0e8c82b46a265';
+String _$searchHash() => r'b624418729a74e253acc5ed23f0a69b925b2197e';
 
 /// Search notifier
 

--- a/lib/storage/providers/storage_detail_provider.dart
+++ b/lib/storage/providers/storage_detail_provider.dart
@@ -80,6 +80,7 @@ class StorageDetail extends _$StorageDetail {
           after: state.storagePageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           storage: storage.copyWith(
             name: homeStorage.name,
@@ -96,6 +97,7 @@ class StorageDetail extends _$StorageDetail {
           cache: false,
         );
         if (results != null) {
+          if (!ref.mounted) return;
           state = state.copyWith(
             storage: storage.copyWith(
               children: storage.children! + results.item1.children!,
@@ -107,6 +109,7 @@ class StorageDetail extends _$StorageDetail {
         }
       }
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: StorageDetailStatus.failure,
         errorMessage: e.message,
@@ -124,6 +127,7 @@ class StorageDetail extends _$StorageDetail {
 
       if (storageId == homeStorage.id) {
         final results = await storageRepository.rootStorage(cache: cache);
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: StorageDetailStatus.success,
           storage: Storage(
@@ -140,12 +144,14 @@ class StorageDetail extends _$StorageDetail {
           cache: cache,
         );
         if (results == null) {
+          if (!ref.mounted) return;
           state = state.copyWith(
             status: StorageDetailStatus.failure,
             errorMessage: '获取位置失败，位置不存在',
           );
           return;
         }
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: StorageDetailStatus.success,
           storage: results.item1,
@@ -154,6 +160,7 @@ class StorageDetail extends _$StorageDetail {
         );
       }
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: StorageDetailStatus.failure,
         errorMessage: e.message,

--- a/lib/storage/providers/storage_detail_provider.g.dart
+++ b/lib/storage/providers/storage_detail_provider.g.dart
@@ -11,13 +11,13 @@ part of 'storage_detail_provider.dart';
 /// Storage detail notifier
 
 @ProviderFor(StorageDetail)
-const storageDetailProvider = StorageDetailFamily._();
+final storageDetailProvider = StorageDetailFamily._();
 
 /// Storage detail notifier
 final class StorageDetailProvider
     extends $NotifierProvider<StorageDetail, StorageDetailState> {
   /// Storage detail notifier
-  const StorageDetailProvider._({
+  StorageDetailProvider._({
     required StorageDetailFamily super.from,
     required String super.argument,
   }) : super(
@@ -74,7 +74,7 @@ final class StorageDetailFamily extends $Family
           StorageDetailState,
           String
         > {
-  const StorageDetailFamily._()
+  StorageDetailFamily._()
     : super(
         retry: null,
         name: r'storageDetailProvider',
@@ -102,7 +102,6 @@ abstract class _$StorageDetail extends $Notifier<StorageDetailState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build(_$args);
     final ref = this.ref as $Ref<StorageDetailState, StorageDetailState>;
     final element =
         ref.element
@@ -112,6 +111,6 @@ abstract class _$StorageDetail extends $Notifier<StorageDetailState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/lib/storage/providers/storage_detail_provider.g.dart
+++ b/lib/storage/providers/storage_detail_provider.g.dart
@@ -61,7 +61,7 @@ final class StorageDetailProvider
   }
 }
 
-String _$storageDetailHash() => r'de86df07359758dd07eb7d264bc36d5aebe8f223';
+String _$storageDetailHash() => r'613a6158ff368c1fda72c4465e552e2cc4d35810';
 
 /// Storage detail notifier
 

--- a/lib/storage/providers/storage_edit_provider.g.dart
+++ b/lib/storage/providers/storage_edit_provider.g.dart
@@ -11,13 +11,13 @@ part of 'storage_edit_provider.dart';
 /// Storage edit notifier
 
 @ProviderFor(StorageEdit)
-const storageEditProvider = StorageEditProvider._();
+final storageEditProvider = StorageEditProvider._();
 
 /// Storage edit notifier
 final class StorageEditProvider
     extends $NotifierProvider<StorageEdit, StorageEditState> {
   /// Storage edit notifier
-  const StorageEditProvider._()
+  StorageEditProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$StorageEdit extends $Notifier<StorageEditState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<StorageEditState, StorageEditState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$StorageEdit extends $Notifier<StorageEditState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/storage/providers/storage_home_provider.dart
+++ b/lib/storage/providers/storage_home_provider.dart
@@ -108,6 +108,7 @@ class StorageHome extends _$StorageHome {
         await _fetchFirstPage(storageRepository, itemType, cache);
       }
     } on MyException catch (e) {
+      if (!ref.mounted) return;
       state = state.copyWith(
         status: StorageHomeStatus.failure,
         errorMessage: e.message,
@@ -126,6 +127,7 @@ class StorageHome extends _$StorageHome {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: StorageHomeStatus.success,
           expiredItems: () => (state.expiredItems ?? []) + results.item1,
@@ -137,6 +139,7 @@ class StorageHome extends _$StorageHome {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: StorageHomeStatus.success,
           nearExpiredItems: () =>
@@ -149,6 +152,7 @@ class StorageHome extends _$StorageHome {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: StorageHomeStatus.success,
           recentlyCreatedItems: () =>
@@ -161,6 +165,7 @@ class StorageHome extends _$StorageHome {
           after: state.pageInfo.endCursor,
           cache: false,
         );
+        if (!ref.mounted) return;
         state = state.copyWith(
           status: StorageHomeStatus.success,
           recentlyEditedItems: () =>
@@ -181,6 +186,7 @@ class StorageHome extends _$StorageHome {
     switch (itemType) {
       case ItemType.expired:
         final results = await storageRepository.expiredItems(cache: cache);
+        if (!ref.mounted) return;
         state = StorageHomeState(
           status: StorageHomeStatus.success,
           expiredItems: results.item1,
@@ -190,6 +196,7 @@ class StorageHome extends _$StorageHome {
         break;
       case ItemType.nearExpired:
         final results = await storageRepository.nearExpiredItems(cache: cache);
+        if (!ref.mounted) return;
         state = StorageHomeState(
           status: StorageHomeStatus.success,
           nearExpiredItems: results.item1,
@@ -201,6 +208,7 @@ class StorageHome extends _$StorageHome {
         final results = await storageRepository.recentlyCreatedItems(
           cache: cache,
         );
+        if (!ref.mounted) return;
         state = StorageHomeState(
           status: StorageHomeStatus.success,
           recentlyCreatedItems: results.item1,
@@ -212,6 +220,7 @@ class StorageHome extends _$StorageHome {
         final results = await storageRepository.recentlyEditedItems(
           cache: cache,
         );
+        if (!ref.mounted) return;
         state = StorageHomeState(
           status: StorageHomeStatus.success,
           recentlyEditedItems: results.item1,
@@ -221,6 +230,7 @@ class StorageHome extends _$StorageHome {
         break;
       case ItemType.all:
         final homepage = await storageRepository.homePage(cache: cache);
+        if (!ref.mounted) return;
         state = StorageHomeState(
           status: StorageHomeStatus.success,
           recentlyCreatedItems: homepage['recentlyCreatedItems'],

--- a/lib/storage/providers/storage_home_provider.g.dart
+++ b/lib/storage/providers/storage_home_provider.g.dart
@@ -44,7 +44,7 @@ final class StorageHomeProvider
   }
 }
 
-String _$storageHomeHash() => r'16ebfd8a0c059eabf54cfa235ec2e5ee360a67a6';
+String _$storageHomeHash() => r'2abea5b3ddcd6313a056b649e042c49895f8e856';
 
 /// Storage home notifier
 

--- a/lib/storage/providers/storage_home_provider.g.dart
+++ b/lib/storage/providers/storage_home_provider.g.dart
@@ -11,13 +11,13 @@ part of 'storage_home_provider.dart';
 /// Storage home notifier
 
 @ProviderFor(StorageHome)
-const storageHomeProvider = StorageHomeProvider._();
+final storageHomeProvider = StorageHomeProvider._();
 
 /// Storage home notifier
 final class StorageHomeProvider
     extends $NotifierProvider<StorageHome, StorageHomeState> {
   /// Storage home notifier
-  const StorageHomeProvider._()
+  StorageHomeProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,7 +53,6 @@ abstract class _$StorageHome extends $Notifier<StorageHomeState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<StorageHomeState, StorageHomeState>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$StorageHome extends $Notifier<StorageHomeState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/lib/user/providers/session_provider.g.dart
+++ b/lib/user/providers/session_provider.g.dart
@@ -11,12 +11,12 @@ part of 'session_provider.dart';
 /// Session Notifier
 
 @ProviderFor(Session)
-const sessionProvider = SessionProvider._();
+final sessionProvider = SessionProvider._();
 
 /// Session Notifier
 final class SessionProvider extends $NotifierProvider<Session, SessionState> {
   /// Session Notifier
-  const SessionProvider._()
+  SessionProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,7 +52,6 @@ abstract class _$Session extends $Notifier<SessionState> {
   @$mustCallSuper
   @override
   void runBuild() {
-    final created = build();
     final ref = this.ref as $Ref<SessionState, SessionState>;
     final element =
         ref.element
@@ -62,6 +61,6 @@ abstract class _$Session extends $Notifier<SessionState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    element.handleCreate(ref, build);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: android_id
-      sha256: f4d1f3b2a3885fce8f77143434b980d2178664c425cf775a840812a84967f778
+      sha256: "50d62501d623a7e7358b3ceffd1bdd9b420292eba66cec8347d33ed10791f28e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   animated_tree_view:
     dependency: "direct main"
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -93,18 +93,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.6"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "7b5b569f3df370590a85029148d6fc66c7d0201fc6f1847c07dd85d365ae9fcd"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.3"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.12.6"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -209,14 +209,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -245,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "701dcfc06da0882883a2657c445103380e53e647060ad8d9dfb710c100996608"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+1"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -261,10 +269,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   custom_lint:
     dependency: "direct dev"
     description:
@@ -317,10 +325,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: dd0e8e02186b2196c7848c9d394a5fd6e5b57a43a546082c5820b1ec72317e33
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "12.2.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -365,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   extended_sliver:
     dependency: "direct main"
     description:
@@ -389,10 +397,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -405,18 +413,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "80a877f5ec570c4fb3b40720a70b6f31e8bb1315a464b4d3e92fe82754d4b21a"
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+3"
+    version: "0.9.4"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "44f24d102e368370951b98ffe86c7325b38349e634578312976607d28cc6d747"
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+6"
+    version: "0.9.5"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -536,10 +544,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "306f0596590e077338312f38837f595c04f28d6cdeeac392d3d74df2f0003687"
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.32"
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -602,10 +610,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: c92d18e1fe994cb06d48aa786c46b142a5633067e8297cff6b5a3ac742620104
+      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
       url: "https://pub.dev"
     source: hosted
-    version: "17.0.0"
+    version: "17.2.3"
   gql:
     dependency: "direct main"
     description:
@@ -666,10 +674,10 @@ packages:
     dependency: "direct main"
     description:
       name: graphql
-      sha256: "297a1680520e7b4d3c5784cfcea11a16d599702911b74a8ab50857c6d58741b9"
+      sha256: a7cb0b5e8719546bf8d4edf5f57c3690ddf0fcce379c0d9d2287fdab73481090
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.3"
+    version: "5.2.4"
   graphs:
     dependency: transitive
     description:
@@ -682,18 +690,26 @@ packages:
     dependency: transitive
     description:
       name: hive_ce
-      sha256: "81d39a03c4c0ba5938260a8c3547d2e71af59defecea21793d57fc3551f0d230"
+      sha256: "8e9980e68643afb1e765d3af32b47996552a64e190d03faf622cea07c1294418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.1"
+    version: "2.19.3"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   hotreloader:
     dependency: transitive
     description:
       name: hotreloader
-      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
+      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   http:
     dependency: "direct main"
     description:
@@ -722,26 +738,26 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.4"
+    version: "4.8.0"
   image_picker:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "788167bcb578b13613b17c3b4a4efae911715f353e36bddc48a0b02a54a8de40"
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+9"
+    version: "0.8.13+17"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -754,10 +770,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: "997d100ce1dda5b1ba4085194c5e36c9f8a1fb7987f6a36ab677a344cd2dc986"
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+2"
+    version: "0.8.13+6"
   image_picker_linux:
     dependency: transitive
     description:
@@ -818,10 +834,10 @@ packages:
     dependency: transitive
     description:
       name: isolate_channel
-      sha256: f3d36f783b301e6b312c3450eeb2656b0e7d1db81331af2a151d9083a3f6b18d
+      sha256: a9d3d620695bc984244dafae00b95e4319d6974b2d77f4b9e1eb4f2efe099094
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2+1"
+    version: "0.6.1"
   jni:
     dependency: transitive
     description:
@@ -830,14 +846,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -850,10 +858,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
+      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.1"
+    version: "6.11.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -882,10 +890,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   logging:
     dependency: "direct main"
     description:
@@ -898,34 +906,34 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -938,18 +946,26 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "023a71afb4d7cfb5529d0f2636aa8b43db66257905b9486d702085989769c5f2"
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.3"
+    version: "7.2.0"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "4feb43bc4eb6c03e832f5fcd637d1abb44b98f9cfa245c58e27382f58859f8f6"
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.1"
+    version: "5.6.4"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.6"
   node_preamble:
     dependency: transitive
     description:
@@ -962,18 +978,18 @@ packages:
     dependency: transitive
     description:
       name: normalize
-      sha256: f78bf0552b9640c76369253f0b8fdabad4f3fbfc06bdae9359e71bee9a5b071b
+      sha256: "703f0af9e6f43a5a71536e977b945238bc89f1a941347e7ba467865a20cc1a9f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1"
+    version: "0.10.0"
   objective_c:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "64e35e1e2e79da4e83f2ace3bf4e5437cef523f46c7db2eba9a1419c49573790"
+      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.3.0"
   octo_image:
     dependency: transitive
     description:
@@ -994,10 +1010,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1026,18 +1042,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "95c68a74d3cab950fd0ed8073d9fab15c1c06eb1f3eec68676e87aabc9ecee5a"
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.21"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "97390a0719146c7c3e71b6866c34f1cde92685933165c1c671984390d2aca776"
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1066,10 +1082,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   photo_view:
     dependency: "direct main"
     description:
@@ -1106,10 +1122,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.5.0"
   process:
     dependency: transitive
     description:
@@ -1170,18 +1186,18 @@ packages:
     dependency: transitive
     description:
       name: quick_actions_android
-      sha256: "1c28eb0809a7f72b3aa9666a13a28189063d96a7cc499f68783c32a5f261ef9e"
+      sha256: "6fbdda87fbedd0602b91f35d870c2cbcb6d053bc863efb76c6e7f60f1d8e3fd6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.26"
+    version: "1.0.30"
   quick_actions_ios:
     dependency: transitive
     description:
       name: quick_actions_ios
-      sha256: a2e08ceb01f9d26e1b1826b1c4f5da6b7b6bbf61bcbaacd8e93dfff58b91f996
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   quick_actions_platform_interface:
     dependency: transitive
     description:
@@ -1190,6 +1206,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   riverpod:
     dependency: transitive
     description:
@@ -1250,34 +1274,34 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "10a0bc25f5f21468e3beeae44e561825aaa02cdc6829438e73b9b64658ff88d9"
+      sha256: f04095a25ff02b202a914174c73ec309570aa93d61098cb4a0a9e715b4aaa465
       url: "https://pub.dev"
     source: hosted
-    version: "9.8.0"
+    version: "9.20.0"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
       name: sentry_dart_plugin
-      sha256: "4b25aa60b5cbb46bb23859ac9212c4de5b22e2b3bc3fecbcd611756ada8973b5"
+      sha256: "2c5f263f8d5aea3cf387a7e03f77e355d35c71bd9a429474d633fbc085b86ceb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: aafbf41c63c98a30b17bdbf3313424d5102db62b08735c44bff810f277e786a5
+      sha256: "4f0a914d8c37e5015d7b86dd42b92dd265948fd31875b43e62ddfc2e7bea0e41"
       url: "https://pub.dev"
     source: hosted
-    version: "9.8.0"
+    version: "9.20.0"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "14c8860d4de93d3a7e53af51bff479598c4e999605290756bbbe45cf65b37840"
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1290,18 +1314,18 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "07d552dbe8e71ed720e5205e760438ff4ecfb76ec3b32ea664350e2ca4b0c43b"
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.16"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1322,10 +1346,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -1383,10 +1407,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "0d6c4e1080176801112ed1111226d13cd4f74947383aabafbd9726a22083aeaa"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.3"
   source_helper:
     dependency: transitive
     description:
@@ -1415,34 +1439,34 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
-      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.2+1"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+2"
+    version: "2.4.2+3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
+      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6"
+    version: "2.5.8"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1503,10 +1527,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.0+1"
   system_info2:
     dependency: transitive
     description:
@@ -1527,26 +1551,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   tuple:
     dependency: "direct main"
     description:
@@ -1575,18 +1599,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "1a109ee074e2a3b17ec3f2785248cb3e93c1e4abab878f637bc33267089f05a3"
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.26"
+    version: "6.3.30"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.6"
+    version: "6.4.1"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1615,10 +1639,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1631,10 +1655,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   value_layout_builder:
     dependency: transitive
     description:
@@ -1663,18 +1687,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.1"
   web:
     dependency: "direct main"
     description:
@@ -1711,34 +1735,34 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.0"
+    version: "4.13.1"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: f754fec262c5bf826615e8c7f035da1c536ba6ad9b1181936fad900d297cb687
+      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.6"
+    version: "4.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.1"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: "8f4fa32670375f4ce9bfe0f1c773e0857dd191f4e6b3518a1dcdeb7a880bae2e"
+      sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.23.3"
+    version: "3.25.1"
   win32:
     dependency: transitive
     description:
@@ -1780,5 +1804,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: "3.38.1"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: "3.44.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "91.0.0"
+  analysis_server_plugin:
+    dependency: transitive
+    description:
+      name: analysis_server_plugin
+      sha256: "26844e7f977087567135d62532b67d5639fe206c5194c3f410ba75e1a04a2747"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
@@ -281,14 +289,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.1"
-  custom_lint_builder:
-    dependency: transitive
-    description:
-      name: custom_lint_builder
-      sha256: "1128db6f58e71d43842f3b9be7465c83f0c47f4dd8918f878dd6ad3b72a32072"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
   custom_lint_core:
     dependency: transitive
     description:
@@ -552,10 +552,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9e2d6907f12cc7d23a846847615941bddee8709bf2bfd274acdf5e80bcf22fde"
+      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   flutter_sticky_header:
     dependency: "direct main"
     description:
@@ -702,14 +702,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
-  hotreloader:
-    dependency: transitive
-    description:
-      name: hotreloader
-      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.4.0"
   http:
     dependency: "direct main"
     description:
@@ -1218,42 +1210,42 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: c406de02bff19d920b832bddfb8283548bfa05ce41c59afba57ce643e116aa59
+      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: a0f68adb078b790faa3c655110a017f9a7b7b079a57bbd40f540e80dce5fcd29
+      sha256: "947b05d04c52a546a2ac6b19ef2a54b08520ff6bdf9f23d67957a4c8df1c3bc0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.7"
+    version: "1.0.0-dev.8"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "7230014155777fc31ba3351bc2cb5a3b5717b11bfafe52b1553cb47d385f8897"
+      sha256: cc1474bc2df55ec3c1da1989d139dcef22cd5e2bd78da382e867a69a8eca2e46
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "4.0.0"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "49894543a42cf7a9954fc4e7366b6d3cb2e6ec0fa07775f660afcdd92d097702"
+      sha256: e43b1537229cc8f487f09b0c20d15dba840acbadcf5fc6dad7ad5e8ab75950dc
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "4.0.0+1"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: "7ef9c43469e9b5ac4e4c3b24d7c30642e47ce1b12cd7dcdd643534db0a72ed13"
+      sha256: "4d2eb0d19bbe7e3323bd0ce4553b2e6170d161a13914bfdd85a3612329edcb43"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   rxdart:
     dependency: "direct main"
     description:
@@ -1803,6 +1795,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: "3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ">=3.10.0 <4.0.0"
-  flutter: "3.38.1" # This must be exact! No ranges allowed.
+  flutter: "3.44.0" # This must be exact! No ranges allowed.
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # Flutter
   web: ^1.1.1
   flutter_riverpod: ^3.0.3
-  riverpod_annotation: ^3.0.3
+  riverpod_annotation: ^4.0.0
   go_router: ^17.0.0
   shared_preferences: ^2.5.3
   url_launcher: ^6.3.2
@@ -75,7 +75,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.10.3
   json_serializable: ^6.11.1
-  riverpod_generator: ^3.0.3
+  riverpod_generator: ^4.0.0+1
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
   sentry_dart_plugin: ^3.2.0

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "skills": {
+    "flutter-add-integration-test": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-add-integration-test/SKILL.md",
+      "computedHash": "4246d3ef5f21bdb7945899056b99cf3863e2bff645a132b41634caaded68da6d"
+    },
+    "flutter-add-widget-preview": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-add-widget-preview/SKILL.md",
+      "computedHash": "369ed3ebdc1f81ee337551ad1d1dd9ec6e768ed2bdf65d32ad442117a6ba79b6"
+    },
+    "flutter-add-widget-test": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-add-widget-test/SKILL.md",
+      "computedHash": "f4ea905ae155d1bca76f5431bf6ed31f31e3d40146493e7ae4285eac39ba4ffd"
+    },
+    "flutter-apply-architecture-best-practices": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-apply-architecture-best-practices/SKILL.md",
+      "computedHash": "baeb208b1cab90c559677626dbd101b96ba93f803cbed85122abdadeb3283a8b"
+    },
+    "flutter-build-responsive-layout": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-build-responsive-layout/SKILL.md",
+      "computedHash": "6d74a9504c4e355c4c62f6fcb6c6dc0df67b56dd6616bea199e4e58f75b7729b"
+    },
+    "flutter-fix-layout-issues": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-fix-layout-issues/SKILL.md",
+      "computedHash": "b2f9789451224e6df8d1d7ac63854c2f1beb30fa35d13ea06fbae9ba2b1b0a7f"
+    },
+    "flutter-implement-json-serialization": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-implement-json-serialization/SKILL.md",
+      "computedHash": "c2cf46854472a452dafa11f862f2bca3d9fe7286a5bb45d85b1efbcebc74b74e"
+    },
+    "flutter-setup-declarative-routing": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-setup-declarative-routing/SKILL.md",
+      "computedHash": "4c2ed2fd729230be581b15d84741688e206632fb2b38af320060cd3518b91179"
+    },
+    "flutter-setup-localization": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-setup-localization/SKILL.md",
+      "computedHash": "fc0811b1b775c52c1b8f7df600f5c52b83029aea0586b8cc55169812affd408f"
+    },
+    "flutter-use-http-package": {
+      "source": "flutter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/flutter-use-http-package/SKILL.md",
+      "computedHash": "bd169b5cee731751f3b32f43c94cfe9495fc8e6c3eb621b785c69e38b77d0e19"
+    }
+  }
+}

--- a/test/board/providers/board_home_provider_test.dart
+++ b/test/board/providers/board_home_provider_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:smarthome/board/providers/board_home_provider.dart'
-    as board_home;
+import 'package:smarthome/board/providers/board_home_provider.dart';
 import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 import 'package:tuple/tuple.dart';
@@ -21,7 +20,7 @@ void main() {
     mockBoardRepository = MockBoardRepository();
     container = ProviderContainer.test(
       overrides: [
-        board_home.boardRepositoryProvider.overrideWithValue(
+        boardRepositoryProvider.overrideWithValue(
           mockBoardRepository,
         ),
       ],
@@ -43,7 +42,7 @@ void main() {
       );
 
       final repository = localContainer.read(
-        board_home.boardRepositoryProvider,
+        boardRepositoryProvider,
       );
       expect(repository.graphqlApiClient, mockGraphQLApiClient);
 
@@ -58,12 +57,12 @@ void main() {
       ], const PageInfo(hasNextPage: false)),
     );
 
-    keepProviderAlive(container, board_home.boardHomeProvider);
-    container.read(board_home.boardHomeProvider);
+    keepProviderAlive(container, boardHomeProvider);
+    container.read(boardHomeProvider);
     await _flush();
 
-    final state = container.read(board_home.boardHomeProvider);
-    expect(state.status, board_home.BoardHomeStatus.success);
+    final state = container.read(boardHomeProvider);
+    expect(state.status, BoardHomeStatus.success);
     expect(state.topics, hasLength(1));
   });
 
@@ -81,13 +80,13 @@ void main() {
       ], const PageInfo(hasNextPage: false)),
     );
 
-    keepProviderAlive(container, board_home.boardHomeProvider);
-    container.read(board_home.boardHomeProvider);
+    keepProviderAlive(container, boardHomeProvider);
+    container.read(boardHomeProvider);
     await _flush();
 
-    await container.read(board_home.boardHomeProvider.notifier).fetch();
+    await container.read(boardHomeProvider.notifier).fetch();
 
-    final state = container.read(board_home.boardHomeProvider);
+    final state = container.read(boardHomeProvider);
     expect(state.topics.map((e) => e.id), ['topic-1', 'topic-2']);
   });
 
@@ -96,12 +95,12 @@ void main() {
       mockBoardRepository.topics(cache: true),
     ).thenThrow(MyException('获取失败'));
 
-    keepProviderAlive(container, board_home.boardHomeProvider);
-    container.read(board_home.boardHomeProvider);
+    keepProviderAlive(container, boardHomeProvider);
+    container.read(boardHomeProvider);
     await _flush();
 
-    final state = container.read(board_home.boardHomeProvider);
-    expect(state.status, board_home.BoardHomeStatus.failure);
+    final state = container.read(boardHomeProvider);
+    expect(state.status, BoardHomeStatus.failure);
     expect(state.errorMessage, '获取失败');
   });
 }

--- a/test/board/providers/comment_edit_provider_test.dart
+++ b/test/board/providers/comment_edit_provider_test.dart
@@ -1,9 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:smarthome/board/providers/board_home_provider.dart'
-    as board_home;
 import 'package:smarthome/board/providers/comment_edit_provider.dart';
+import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 
 import '../../helpers/board_test_utils.dart';
@@ -17,7 +16,7 @@ void main() {
     mockBoardRepository = MockBoardRepository();
     container = ProviderContainer.test(
       overrides: [
-        board_home.boardRepositoryProvider.overrideWithValue(
+        boardRepositoryProvider.overrideWithValue(
           mockBoardRepository,
         ),
       ],

--- a/test/board/providers/topic_edit_provider_test.dart
+++ b/test/board/providers/topic_edit_provider_test.dart
@@ -1,9 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:smarthome/board/providers/board_home_provider.dart'
-    as board_home;
 import 'package:smarthome/board/providers/topic_edit_provider.dart';
+import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 
 import '../../helpers/board_test_utils.dart';
@@ -17,7 +16,7 @@ void main() {
     mockBoardRepository = MockBoardRepository();
     container = ProviderContainer.test(
       overrides: [
-        board_home.boardRepositoryProvider.overrideWithValue(
+        boardRepositoryProvider.overrideWithValue(
           mockBoardRepository,
         ),
       ],


### PR DESCRIPTION
## 变更内容

### Flutter 3.44.0 升级
- 更新 flutter 版本约束从 3.41.9 到 3.44.0
- 更新 66 个依赖包

### Riverpod 包升级
- riverpod_annotation: 3.0.3 -> 4.0.0
- riverpod_generator: 3.0.3 -> 4.0.0+1
- flutter_riverpod: 3.0.3 -> 3.1.0
- riverpod: 3.0.3 -> 3.1.0
- riverpod_lint: 3.0.3 -> 3.1.0
- 重新生成所有 .g.dart 文件

### 代码优化
- 为 7 个 auto-dispose provider 添加 ref.mounted 保护，防止竞态条件
- 移除 board_home_provider.dart 中重复的 boardRepositoryProvider 定义
- 修复相关导入和测试文件

## 破坏性变更
Flutter 3.44 的破坏性变更对本项目无影响（已验证）。