### PR TITLE
fix(storage): 移除废弃日期选择依赖

### DIFF
--- a/lib/storage/view/item_edit_page.dart
+++ b/lib/storage/view/item_edit_page.dart
@@ -1,4 +1,3 @@
-import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,6 +7,7 @@ import 'package:smarthome/storage/view/widgets/storage_picker_formfield.dart';
 import 'package:smarthome/utils/constants.dart';
 import 'package:smarthome/utils/date_format_extension.dart';
 import 'package:smarthome/utils/show_snack_bar.dart';
+import 'package:smarthome/widgets/date_time_picker_formfield.dart';
 import 'package:smarthome/widgets/home_page.dart';
 import 'package:smarthome/widgets/rounded_raised_button.dart';
 
@@ -180,27 +180,8 @@ class _ItemEditPageState extends ConsumerState<ItemEditPage> {
                   },
                   focusNode: _priceFocusNode,
                 ),
-                DateTimeField(
+                DateTimePickerFormField(
                   format: DateTime.now().localFormat,
-                  onShowPicker: (context, currentValue) async {
-                    final date = await showDatePicker(
-                      context: context,
-                      firstDate: DateTime(1900),
-                      initialDate: currentValue ?? DateTime.now(),
-                      lastDate: DateTime(2100),
-                    );
-                    if (date != null && context.mounted) {
-                      final time = await showTimePicker(
-                        context: context,
-                        initialTime: TimeOfDay.fromDateTime(
-                          currentValue ?? DateTime.now(),
-                        ),
-                      );
-                      return DateTimeField.combine(date, time);
-                    } else {
-                      return currentValue;
-                    }
-                  },
                   initialValue: widget.isEditing
                       ? widget.item!.expiredAt?.toLocal()
                       : null,

--- a/lib/widgets/date_time_picker_formfield.dart
+++ b/lib/widgets/date_time_picker_formfield.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class DateTimePickerFormField extends StatefulWidget {
+  final InputDecoration decoration;
+  final DateFormat format;
+  final DateTime? initialValue;
+  final ValueChanged<DateTime?> onChanged;
+
+  const DateTimePickerFormField({
+    super.key,
+    required this.decoration,
+    required this.format,
+    required this.onChanged,
+    this.initialValue,
+  });
+
+  @override
+  State<DateTimePickerFormField> createState() =>
+      _DateTimePickerFormFieldState();
+}
+
+class _DateTimePickerFormFieldState extends State<DateTimePickerFormField> {
+  late final TextEditingController _controller;
+  DateTime? _value;
+
+  @override
+  void didUpdateWidget(covariant DateTimePickerFormField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialValue != oldWidget.initialValue) {
+      _value = widget.initialValue;
+      _syncText();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.initialValue;
+    _controller = TextEditingController();
+    _syncText();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: _controller,
+      decoration: widget.decoration.copyWith(
+        suffixIcon: _value == null
+            ? const Icon(Icons.event)
+            : IconButton(
+                tooltip: '清除',
+                icon: const Icon(Icons.clear),
+                onPressed: () => _updateValue(null),
+              ),
+      ),
+      readOnly: true,
+      onTap: _pickDateTime,
+    );
+  }
+
+  Future<void> _pickDateTime() async {
+    final currentValue = _value ?? DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      firstDate: DateTime(1900),
+      initialDate: currentValue,
+      lastDate: DateTime(2100),
+    );
+    if (date == null || !mounted) {
+      return;
+    }
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(currentValue),
+    );
+    if (!mounted) {
+      return;
+    }
+
+    _updateValue(
+      DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time?.hour ?? 0,
+        time?.minute ?? 0,
+      ),
+    );
+  }
+
+  void _syncText() {
+    _controller.text = _value == null
+        ? ''
+        : widget.format.format(_value!.toLocal());
+  }
+
+  void _updateValue(DateTime? value) {
+    setState(() {
+      _value = value;
+      _syncText();
+    });
+    widget.onChanged(value);
+  }
+}

--- a/lib/widgets/date_time_picker_formfield.dart
+++ b/lib/widgets/date_time_picker_formfield.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
 import 'package:intl/intl.dart';
 
 class DateTimePickerFormField extends StatefulWidget {
@@ -109,4 +110,35 @@ class _DateTimePickerFormFieldState extends State<DateTimePickerFormField> {
     });
     widget.onChanged(value);
   }
+}
+
+Widget _dateTimePickerPreviewFrame(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(child: SizedBox(width: 360, child: child)),
+    ),
+  );
+}
+
+@Preview(name: 'DateTimePickerFormField empty')
+Widget dateTimePickerFormFieldEmptyPreview() {
+  return _dateTimePickerPreviewFrame(
+    DateTimePickerFormField(
+      decoration: const InputDecoration(labelText: '有效期至'),
+      format: DateFormat.yMMMd().add_Hms(),
+      onChanged: (_) {},
+    ),
+  );
+}
+
+@Preview(name: 'DateTimePickerFormField selected')
+Widget dateTimePickerFormFieldSelectedPreview() {
+  return _dateTimePickerPreviewFrame(
+    DateTimePickerFormField(
+      decoration: const InputDecoration(labelText: '有效期至'),
+      format: DateFormat.yMMMd().add_Hms(),
+      initialValue: DateTime(2026, 5, 21, 12, 30),
+      onChanged: (_) {},
+    ),
+  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -313,14 +313,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  datetime_picker_formfield:
-    dependency: "direct main"
-    description:
-      name: datetime_picker_formfield
-      sha256: "6d0412c98cc5da18a5dca1f81f82a834fbacdb5d249fd6d9bed42d912339720e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   device_info_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,6 @@ dependencies:
 
   # Widget
   webview_flutter: ^4.13.0
-  datetime_picker_formfield: ^2.0.1
   flutter_markdown_selectionarea: ^0.6.17+1
   cached_network_image: ^3.4.1
   dropdown_search: ^6.0.2

--- a/test/widgets/date_time_picker_formfield_test.dart
+++ b/test/widgets/date_time_picker_formfield_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:smarthome/widgets/date_time_picker_formfield.dart';
+
+void main() {
+  Widget buildSubject({
+    DateTime? initialValue,
+    ValueChanged<DateTime?>? onChanged,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: DateTimePickerFormField(
+          decoration: const InputDecoration(labelText: '有效期至'),
+          format: DateFormat('yyyy-MM-dd HH:mm'),
+          initialValue: initialValue,
+          onChanged: onChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows formatted initial value', (tester) async {
+    await tester.pumpWidget(
+      buildSubject(initialValue: DateTime(2026, 5, 21, 12, 30)),
+    );
+
+    expect(find.text('有效期至'), findsOneWidget);
+    expect(find.text('2026-05-21 12:30'), findsOneWidget);
+    expect(find.byIcon(Icons.clear), findsOneWidget);
+    expect(find.byIcon(Icons.event), findsNothing);
+  });
+
+  testWidgets('shows event icon when value is empty', (tester) async {
+    await tester.pumpWidget(buildSubject());
+
+    expect(find.text('有效期至'), findsOneWidget);
+    expect(find.byIcon(Icons.event), findsOneWidget);
+    expect(find.byIcon(Icons.clear), findsNothing);
+  });
+
+  testWidgets('clears selected value', (tester) async {
+    DateTime? changedValue = DateTime(2026, 5, 21, 12, 30);
+    await tester.pumpWidget(
+      buildSubject(
+        initialValue: changedValue,
+        onChanged: (value) => changedValue = value,
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.clear));
+    await tester.pump();
+
+    expect(changedValue, isNull);
+    expect(find.text('2026-05-21 12:30'), findsNothing);
+    expect(find.byIcon(Icons.event), findsOneWidget);
+  });
+
+  testWidgets('opens date picker when tapped', (tester) async {
+    await tester.pumpWidget(buildSubject());
+
+    await tester.tap(find.byType(TextFormField));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DatePickerDialog), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 变更内容

- 移除已 discontinued 的 `datetime_picker_formfield` 依赖。
- 新增 `lib/widgets/date_time_picker_formfield.dart`，使用 Flutter 原生 `showDatePicker` / `showTimePicker` 封装日期时间表单字段。
- `ItemEditPage` 改为使用新的通用 `DateTimePickerFormField`。
- 为 `DateTimePickerFormField` 添加空值/已选中状态的 Widget Preview。
- 补充 `DateTimePickerFormField` widget test，覆盖初始显示、空值图标、清除回调和点击打开日期选择器。

## 背景

`datetime_picker_formfield` 已停止维护，当前项目只在物品编辑页的“有效期至”字段使用它，且原逻辑本身已经依赖 Flutter 官方日期/时间选择器，因此可以用本地控件替代并减少外部依赖。

## 验证

- `flutter pub get`
- `dart format lib/storage/view/item_edit_page.dart lib/widgets/date_time_picker_formfield.dart test/widgets/date_time_picker_formfield_test.dart`
- `flutter test --no-pub test/widgets/date_time_picker_formfield_test.dart`
- `flutter analyze --no-pub lib/storage/view/item_edit_page.dart lib/widgets/date_time_picker_formfield.dart test/widgets/date_time_picker_formfield_test.dart`

备注：全量 `flutter analyze --no-pub` 在拆分后一次运行超过 5 分钟超时；本次对改动相关文件做了窄范围分析。