### PR TITLE
feat(ui): 添加宽屏导航栏

### DIFF
--- a/lib/widgets/home_page.dart
+++ b/lib/widgets/home_page.dart
@@ -6,6 +6,9 @@ import 'package:smarthome/widgets/conditional_parent_widget.dart';
 import 'package:smarthome/widgets/drawer.dart';
 import 'package:smarthome/widgets/tab_selector.dart';
 
+const double _navigationRailBreakpoint = 720;
+const double _extendedNavigationRailBreakpoint = 1200;
+
 class MyHomePage extends ConsumerWidget {
   final String title;
   final List<Widget>? actions;
@@ -29,33 +32,62 @@ class MyHomePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final location = GoRouterState.of(context).matchedLocation;
+    final activeTab = _getCurrentTab(location);
 
-    return MySliverScaffold(
-      title: Text(title),
-      actions: actions,
-      slivers: slivers,
-      drawer: const MyDrawer(),
-      floatingActionButton: floatingActionButton,
-      onRefresh: onRefresh,
-      canPop: canPop,
-      onPopInvokedWithResult: onPopInvokedWithResult,
-      bottomNavigationBar: TabSelector(
-        activeTab: _getCurrentTab(location),
-        onTabSelected: (tab) {
-          switch (tab) {
-            case AppTab.storage:
-              context.go('/storage');
-              break;
-            case AppTab.blog:
-              context.go('/blog');
-              break;
-            case AppTab.board:
-              context.go('/board');
-              break;
-          }
-        },
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final showRail = constraints.maxWidth >= _navigationRailBreakpoint;
+        final extendRail =
+            constraints.maxWidth >= _extendedNavigationRailBreakpoint;
+
+        final page = MySliverScaffold(
+          title: Text(title),
+          actions: actions,
+          slivers: slivers,
+          drawer: const MyDrawer(),
+          floatingActionButton: floatingActionButton,
+          onRefresh: onRefresh,
+          canPop: canPop,
+          onPopInvokedWithResult: onPopInvokedWithResult,
+          bottomNavigationBar: showRail
+              ? null
+              : TabSelector(
+                  activeTab: activeTab,
+                  onTabSelected: (tab) => _goToTab(context, tab),
+                ),
+        );
+
+        if (!showRail) {
+          return page;
+        }
+
+        return Row(
+          children: [
+            RailTabSelector(
+              activeTab: activeTab,
+              extended: extendRail,
+              onTabSelected: (tab) => _goToTab(context, tab),
+            ),
+            const VerticalDivider(width: 1),
+            Expanded(child: page),
+          ],
+        );
+      },
     );
+  }
+
+  void _goToTab(BuildContext context, AppTab tab) {
+    switch (tab) {
+      case AppTab.storage:
+        context.go('/storage');
+        break;
+      case AppTab.blog:
+        context.go('/blog');
+        break;
+      case AppTab.board:
+        context.go('/board');
+        break;
+    }
   }
 
   AppTab _getCurrentTab(String location) {

--- a/lib/widgets/tab_selector.dart
+++ b/lib/widgets/tab_selector.dart
@@ -4,11 +4,13 @@ import 'package:smarthome/core/core.dart';
 class TabSelector extends StatelessWidget {
   final AppTab activeTab;
   final Function(AppTab) onTabSelected;
+  final bool extended;
 
   const TabSelector({
     super.key,
     required this.activeTab,
     required this.onTabSelected,
+    this.extended = false,
   });
 
   @override
@@ -16,6 +18,39 @@ class TabSelector extends StatelessWidget {
     return NavigationBar(
       destinations: AppTab.values
           .map((tab) => NavigationDestination(icon: tab.icon, label: tab.name))
+          .toList(),
+      selectedIndex: AppTab.values.indexOf(activeTab),
+      onDestinationSelected: (index) => onTabSelected(AppTab.values[index]),
+    );
+  }
+}
+
+class RailTabSelector extends StatelessWidget {
+  final AppTab activeTab;
+  final Function(AppTab) onTabSelected;
+  final bool extended;
+
+  const RailTabSelector({
+    super.key,
+    required this.activeTab,
+    required this.onTabSelected,
+    this.extended = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationRail(
+      extended: extended,
+      labelType: extended
+          ? NavigationRailLabelType.none
+          : NavigationRailLabelType.selected,
+      destinations: AppTab.values
+          .map(
+            (tab) => NavigationRailDestination(
+              icon: tab.icon,
+              label: Text(tab.name),
+            ),
+          )
           .toList(),
       selectedIndex: AppTab.values.indexOf(activeTab),
       onDestinationSelected: (index) => onTabSelected(AppTab.values[index]),

--- a/test/widgets/tab_selector_test.dart
+++ b/test/widgets/tab_selector_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smarthome/core/core.dart';
+import 'package:smarthome/widgets/tab_selector.dart';
+
+void main() {
+  testWidgets('TabSelector uses bottom navigation on compact layouts', (
+    tester,
+  ) async {
+    AppTab? selectedTab;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: TabSelector(
+            activeTab: AppTab.storage,
+            onTabSelected: (tab) => selectedTab = tab,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(find.byType(NavigationRail), findsNothing);
+
+    await tester.tap(find.text('博客'));
+    await tester.pump();
+
+    expect(selectedTab, AppTab.blog);
+  });
+
+  testWidgets('RailTabSelector uses navigation rail on wide layouts', (
+    tester,
+  ) async {
+    AppTab? selectedTab;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RailTabSelector(
+            activeTab: AppTab.storage,
+            onTabSelected: (tab) => selectedTab = tab,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(NavigationBar), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.chat));
+    await tester.pump();
+
+    expect(selectedTab, AppTab.board);
+  });
+}


### PR DESCRIPTION
## 变更

- 在应用主外壳中根据可用宽度切换底部 `NavigationBar` 和侧边 `NavigationRail`
- 为超宽窗口启用展开的侧边导航
- 补充 `TabSelector`/`RailTabSelector` 的 widget test，覆盖 tab 点击行为

## 背景

响应 #79 的第一阶段，只处理全局导航外壳，避免一次性改动所有业务页面布局。

## 验证

- `flutter analyze --no-pub`
- `flutter test --no-pub test\widgets\tab_selector_test.dart`
