### PR TITLE
chore(deps): 更新依赖并迁移 Riverpod lint 配置

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,9 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+plugins:
+  riverpod_lint: 3.1.3
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`
@@ -27,6 +30,3 @@ linter:
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
-analyzer:
-  plugins:
-    - custom_lint

--- a/lib/storage/view/consumable_edit_page.dart
+++ b/lib/storage/view/consumable_edit_page.dart
@@ -91,7 +91,7 @@ class _ConsumableEditPageState extends ConsumerState<ConsumableEditPage> {
                   return items;
                 },
                 showClearButton: true,
-                onChanged: (Item? value) {
+                onSelected: (Item? value) {
                   setState(() {
                     selectedItem = value;
                   });

--- a/lib/widgets/dropdown_search.dart
+++ b/lib/widgets/dropdown_search.dart
@@ -55,7 +55,7 @@ class MyDropdownSearch<T> extends StatelessWidget {
         clearButtonProps: const ClearButtonProps(isVisible: true),
       ),
       items: items,
-      onChanged: onChanged,
+      onSelected: onChanged,
       selectedItem: selectedItem,
       validator: validator,
       autoValidateMode: autoValidateMode,

--- a/lib/widgets/dropdown_search.dart
+++ b/lib/widgets/dropdown_search.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 class MyDropdownSearch<T> extends StatelessWidget {
   final String? label;
   final DropdownSearchOnFind<T>? items;
-  final ValueChanged<T?>? onChanged;
+  final ValueChanged<T?>? onSelected;
   final T? selectedItem;
   final bool showClearButton;
   final String? Function(T?)? validator;
@@ -14,7 +14,7 @@ class MyDropdownSearch<T> extends StatelessWidget {
     super.key,
     this.label,
     this.items,
-    this.onChanged,
+    this.onSelected,
     this.selectedItem,
     this.showClearButton = false,
     this.validator,
@@ -55,7 +55,7 @@ class MyDropdownSearch<T> extends StatelessWidget {
         clearButtonProps: const ClearButtonProps(isVisible: true),
       ),
       items: items,
-      onSelected: onChanged,
+      onSelected: onSelected,
       selectedItem: selectedItem,
       validator: validator,
       autoValidateMode: autoValidateMode,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
-  analysis_server_plugin:
-    dependency: transitive
-    description:
-      name: analysis_server_plugin
-      sha256: "26844e7f977087567135d62532b67d5639fe206c5194c3f410ba75e1a04a2747"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3"
+    version: "99.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "12.1.0"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
+      sha256: bf559bc54530827a92cc4d9ee340fc76b4f17f386218c2b9e7cd33ed468a7e4d
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.11"
-  analyzer_plugin:
-    dependency: transitive
-    description:
-      name: analyzer_plugin
-      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.10"
+    version: "0.3.2"
   android_id:
     dependency: "direct main"
     description:
@@ -185,14 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
-  ci:
-    dependency: transitive
-    description:
-      name: ci
-      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   cli_config:
     dependency: transitive
     description:
@@ -281,54 +257,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
-  custom_lint:
-    dependency: "direct dev"
-    description:
-      name: custom_lint
-      sha256: "751ee9440920f808266c3ec2553420dea56d3c7837dd2d62af76b11be3fcece5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
-  custom_lint_core:
-    dependency: transitive
-    description:
-      name: custom_lint_core
-      sha256: "85b339346154d5646952d44d682965dfe9e12cae5febd706f0db3aa5010d6423"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
-  custom_lint_visitor:
-    dependency: transitive
-    description:
-      name: custom_lint_visitor
-      sha256: "91f2a81e9f0abb4b9f3bb529f78b6227ce6050300d1ae5b1e2c69c66c7a566d8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0+8.4.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   device_info_plus:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.0"
+    version: "13.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      sha256: "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.3"
+    version: "8.1.0"
   diffutil_dart:
     dependency: transitive
     description:
@@ -393,6 +345,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -544,10 +504,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
+      sha256: be3aa640f053064e2238f8a308baa5be7270645e8b53b08484fd305bd5c1eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2-dev.2"
   flutter_sticky_header:
     dependency: "direct main"
     description:
@@ -834,18 +794,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.2"
+    version: "6.14.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -994,18 +954,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: transitive
     description:
@@ -1202,42 +1162,34 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
+      sha256: da7233961958420e9d80edf4b7a735d5b6b732fe2381d2a12a388562e2042b3f
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2-dev.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "947b05d04c52a546a2ac6b19ef2a54b08520ff6bdf9f23d67957a4c8df1c3bc0"
+      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.8"
+    version: "1.0.0-dev.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: cc1474bc2df55ec3c1da1989d139dcef22cd5e2bd78da382e867a69a8eca2e46
+      sha256: b7fec3dcdef4cc724116b9cad9fd1ca90fb241083cc16e9cf42a85256be7e87e
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.3-dev.2"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: e43b1537229cc8f487f09b0c20d15dba840acbadcf5fc6dad7ad5e8ab75950dc
+      sha256: "2ba125d0f0ece0b7f2a549613803ea1d4a5e1c8b887588223b19ed8671237504"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0+1"
-  riverpod_lint:
-    dependency: "direct dev"
-    description:
-      name: riverpod_lint
-      sha256: "4d2eb0d19bbe7e3323bd0ce4553b2e6170d161a13914bfdd85a3612329edcb43"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
+    version: "4.0.4-dev.3"
   rxdart:
     dependency: "direct main"
     description:
@@ -1282,18 +1234,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.2"
+    version: "13.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1399,10 +1351,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1751,18 +1703,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: a1fc9eb9248baa05dfc12ed5b66e377b3e23f095eec078e0371622b9033810d9
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.2.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      sha256: "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -1787,14 +1739,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  yaml_edit:
-    dependency: transitive
-    description:
-      name: yaml_edit
-      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.4"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: "3.44.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -341,10 +341,10 @@ packages:
     dependency: "direct main"
     description:
       name: dropdown_search
-      sha256: c29b3e5147a82a06a4a08b3b574c51cb48cc17ad89893d53ee72a6f86643622e
+      sha256: f9414cca28d6414fdc1250f78a052bcb7ddb596f5a1affbca8e79737a979a60a
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.0"
   dynamic_color:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   graphql: ^5.2.3
   http: ^1.6.0
   equatable: ^2.0.7
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
   enum_to_string: ^2.2.1
   version: ^3.0.2
   tuple: ^2.0.2
@@ -34,16 +34,16 @@ dependencies:
 
   # Flutter
   web: ^1.1.1
-  flutter_riverpod: ^3.0.3
-  riverpod_annotation: ^4.0.0
+  flutter_riverpod: ^3.3.1
+  riverpod_annotation: ^4.0.2
   go_router: ^17.0.0
   shared_preferences: ^2.5.3
   url_launcher: ^6.3.2
   quick_actions: ^1.1.0
   android_id: ^0.5.0
-  device_info_plus: ^12.4.0
-  package_info_plus: ^9.0.0
-  share_plus: ^12.0.2
+  device_info_plus: ^13.1.0
+  package_info_plus: ^10.1.0
+  share_plus: ^13.1.0
   flutter_keyboard_visibility: ^6.0.0
   image_picker: ^1.2.1
   sentry_flutter: ^9.8.0
@@ -73,13 +73,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.10.3
-  json_serializable: ^6.11.1
+  json_serializable: ^6.14.0
   riverpod_generator: ^4.0.0+1
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
   sentry_dart_plugin: ^3.2.0
-  custom_lint: ^0.8.1
-  riverpod_lint: ^3.0.3
   mockito: ">=5.5.1 <5.7.0"
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,9 +41,9 @@ dependencies:
   url_launcher: ^6.3.2
   quick_actions: ^1.1.0
   android_id: ^0.5.0
-  device_info_plus: ^12.2.0
+  device_info_plus: ^12.4.0
   package_info_plus: ^9.0.0
-  share_plus: ^12.0.1
+  share_plus: ^12.0.2
   flutter_keyboard_visibility: ^6.0.0
   image_picker: ^1.2.1
   sentry_flutter: ^9.8.0
@@ -53,7 +53,7 @@ dependencies:
   webview_flutter: ^4.13.0
   flutter_markdown_selectionarea: ^0.6.17+1
   cached_network_image: ^3.4.1
-  dropdown_search: ^6.0.2
+  dropdown_search: ^7.0.0
   flutter_sticky_header: ^0.8.0
   extended_sliver: ^2.1.3
   animated_tree_view: ^2.3.0
@@ -80,7 +80,7 @@ dev_dependencies:
   sentry_dart_plugin: ^3.2.0
   custom_lint: ^0.8.1
   riverpod_lint: ^3.0.3
-  mockito: ^5.5.1
+  mockito: ">=5.5.1 <5.7.0"
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 变更

- 升级 Renovate 相关依赖，包括 `dropdown_search` 7、`device_info_plus` 13、`package_info_plus` 10、`share_plus` 13、`json_annotation` 4.12、`json_serializable` 6.14 以及 Riverpod 相关依赖组合。
- 适配 `dropdown_search` 7 的 API 变更，将本地 `MyDropdownSearch` 封装和调用处从 `onChanged` 迁移到 `onSelected`。
- 移除不再活跃维护的 `custom_lint` dev dependency，并按 `riverpod_lint` 3.1.3 当前方式改为在 `analysis_options.yaml` 使用 `analysis_server_plugin` 配置。
- 将 `mockito` 约束限制在 `<5.7.0`，避免 analyzer 13 与当前 Riverpod generator 组合冲突。

## 背景

响应 #408 中 Renovate 依赖面板的失败项。当前分支已从单纯清理 Renovate 失败项扩展为更新可落地的依赖组合，并迁移 Riverpod lint 到新的插件安装方式。

## 验证

- `dart run build_runner build`
- `flutter analyze --no-pub`
- `flutter test --no-pub`