### PR TITLE
feat(board): 支持评论链接跳转

### DIFF
--- a/lib/board/board.dart
+++ b/lib/board/board.dart
@@ -1,5 +1,6 @@
 export 'providers/providers.dart';
 export 'repository/board_repository.dart';
+export 'view/comment_link_page.dart';
 export 'view/home_page.dart';
 export 'view/settings/comment_order_page.dart';
 export 'view/topic_detail_page.dart';

--- a/lib/board/graphql/queries/comment.dart
+++ b/lib/board/graphql/queries/comment.dart
@@ -1,0 +1,26 @@
+const String commentQuery = r'''
+query comment($commentId: ID!) {
+  node(id: $commentId) {
+    ... on CommentType {
+      id
+      body
+      user {
+        username
+        avatarUrl
+      }
+      createdAt
+      editedAt
+      parent {
+        id
+      }
+      replyTo {
+        username
+      }
+      topic {
+        id
+        title
+      }
+    }
+  }
+}
+''';

--- a/lib/board/graphql/queries/queries.dart
+++ b/lib/board/graphql/queries/queries.dart
@@ -1,2 +1,3 @@
+export 'comment.dart';
 export 'topic_detail.dart';
 export 'topics.dart';

--- a/lib/board/providers/topic_detail_provider.dart
+++ b/lib/board/providers/topic_detail_provider.dart
@@ -1,9 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:smarthome/board/model/board.dart';
 import 'package:smarthome/core/core.dart';
 import 'package:smarthome/utils/exceptions.dart';
 
 part 'topic_detail_provider.g.dart';
+
+final commentProvider = FutureProvider.autoDispose.family<Comment, String>((
+  ref,
+  commentId,
+) async {
+  final boardRepository = ref.read(boardRepositoryProvider);
+  return boardRepository.comment(commentId: commentId);
+});
 
 /// Topic detail status
 enum TopicDetailStatus { initial, loading, success, failure }
@@ -60,9 +69,15 @@ class TopicDetail extends _$TopicDetail {
   }
 
   /// Initialize with descending order and load data
-  void initialize({bool descending = true}) {
+  Future<void> initialize({
+    bool descending = true,
+    String? targetCommentId,
+  }) async {
     _descending = descending;
-    _loadTopic(cache: true, showLoading: true);
+    await _loadTopic(cache: true, showLoading: true);
+    if (targetCommentId != null && targetCommentId.isNotEmpty) {
+      await loadUntilCommentAvailable(targetCommentId);
+    }
   }
 
   /// Refresh topic data
@@ -101,6 +116,24 @@ class TopicDetail extends _$TopicDetail {
         errorMessage: e.message,
       );
     }
+  }
+
+  Future<bool> loadUntilCommentAvailable(String commentId) async {
+    if (state.comments.any((comment) => comment.id == commentId)) {
+      return true;
+    }
+
+    while (!state.hasReachedMax) {
+      await fetchMore(descending: _descending);
+      if (state.comments.any((comment) => comment.id == commentId)) {
+        return true;
+      }
+      if (state.status == TopicDetailStatus.failure) {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   Future<void> _loadTopic({

--- a/lib/board/providers/topic_detail_provider.g.dart
+++ b/lib/board/providers/topic_detail_provider.g.dart
@@ -61,7 +61,7 @@ final class TopicDetailProvider
   }
 }
 
-String _$topicDetailHash() => r'f3bfc5e56fa6f99ad60a9352ccd73461a22e053e';
+String _$topicDetailHash() => r'3c2a3c63bd109a86203a7abd00dde78acac562a4';
 
 /// Topic detail notifier
 

--- a/lib/board/repository/board_repository.dart
+++ b/lib/board/repository/board_repository.dart
@@ -3,6 +3,7 @@ import 'package:smarthome/board/graphql/mutations/mutations.dart';
 import 'package:smarthome/board/graphql/queries/queries.dart';
 import 'package:smarthome/board/model/board.dart';
 import 'package:smarthome/core/core.dart';
+import 'package:smarthome/utils/exceptions.dart' as exceptions;
 import 'package:smarthome/utils/graphql_helper.dart';
 import 'package:tuple/tuple.dart';
 
@@ -10,6 +11,20 @@ class BoardRepository {
   final GraphQLApiClient graphqlApiClient;
 
   BoardRepository({required this.graphqlApiClient});
+
+  Future<Comment> comment({required String commentId}) async {
+    final options = QueryOptions(
+      document: gql(commentQuery),
+      variables: {'commentId': commentId},
+      fetchPolicy: FetchPolicy.networkOnly,
+    );
+    final result = await graphqlApiClient.query(options);
+    final Map<String, dynamic>? json = result.data!['node'];
+    if (json == null) {
+      throw const exceptions.ServerException('评论不存在');
+    }
+    return Comment.fromJson(json);
+  }
 
   Future<Comment> addComment({
     required String topicId,

--- a/lib/board/view/comment_link_page.dart
+++ b/lib/board/view/comment_link_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:smarthome/board/providers/topic_detail_provider.dart';
+import 'package:smarthome/board/view/topic_detail_page.dart';
+import 'package:smarthome/widgets/center_loading_indicator.dart';
+import 'package:smarthome/widgets/error_message_button.dart';
+
+class CommentLinkPage extends ConsumerWidget {
+  final String commentId;
+
+  const CommentLinkPage({super.key, required this.commentId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final comment = ref.watch(commentProvider(commentId));
+
+    return comment.when(
+      data: (comment) {
+        final topicId = comment.topic?.id;
+        if (topicId == null || topicId.isEmpty) {
+          return Scaffold(
+            body: ErrorMessageButton(
+              message: '评论没有对应话题',
+              onPressed: () => ref.invalidate(commentProvider(commentId)),
+            ),
+          );
+        }
+        return TopicDetailPage(topicId: topicId, targetCommentId: comment.id);
+      },
+      error: (error, stackTrace) => Scaffold(
+        body: ErrorMessageButton(
+          message: error.toString(),
+          onPressed: () => ref.invalidate(commentProvider(commentId)),
+        ),
+      ),
+      loading: () => const Scaffold(body: CenterLoadingIndicator()),
+    );
+  }
+}

--- a/lib/board/view/topic_detail_page.dart
+++ b/lib/board/view/topic_detail_page.dart
@@ -18,25 +18,41 @@ import 'package:smarthome/widgets/markdown.dart';
 
 class TopicDetailPage extends StatelessWidget {
   final String topicId;
+  final String? targetCommentId;
 
-  const TopicDetailPage({super.key, required this.topicId});
+  const TopicDetailPage({
+    super.key,
+    required this.topicId,
+    this.targetCommentId,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return TopicDetailScreen(topicId: topicId);
+    return TopicDetailScreen(
+      topicId: topicId,
+      targetCommentId: targetCommentId,
+    );
   }
 }
 
 class TopicDetailScreen extends ConsumerStatefulWidget {
   final String topicId;
+  final String? targetCommentId;
 
-  const TopicDetailScreen({super.key, required this.topicId});
+  const TopicDetailScreen({
+    super.key,
+    required this.topicId,
+    this.targetCommentId,
+  });
 
   @override
   ConsumerState<TopicDetailScreen> createState() => _TopicDetailScreenState();
 }
 
 class _TopicDetailScreenState extends ConsumerState<TopicDetailScreen> {
+  final Map<String, GlobalKey> _commentKeys = {};
+  String? _scrolledTargetCommentId;
+
   @override
   void initState() {
     super.initState();
@@ -44,8 +60,19 @@ class _TopicDetailScreenState extends ConsumerState<TopicDetailScreen> {
       final descending = ref.read(settingsProvider).commentDescending;
       ref
           .read(topicDetailProvider(widget.topicId).notifier)
-          .initialize(descending: descending);
+          .initialize(
+            descending: descending,
+            targetCommentId: widget.targetCommentId,
+          );
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant TopicDetailScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.targetCommentId != widget.targetCommentId) {
+      _scrolledTargetCommentId = null;
+    }
   }
 
   @override
@@ -91,6 +118,7 @@ class _TopicDetailScreenState extends ConsumerState<TopicDetailScreen> {
     });
 
     final state = ref.watch(topicDetailProvider(widget.topicId));
+    _scrollToTargetComment(state);
 
     return MySliverScaffold(
       title: Text(state.topic.title ?? ''),
@@ -327,15 +355,22 @@ class _TopicDetailScreenState extends ConsumerState<TopicDetailScreen> {
         if (state.status == TopicDetailStatus.success)
           SliverInfiniteList<Comment>(
             items: state.comments,
-            itemBuilder: (context, item) => CommentItem(
-              comment: item,
-              showMenu: loginUser == item.user,
-              onEdit: () {
-                ref
-                    .read(topicDetailProvider(widget.topicId).notifier)
-                    .refresh(descending: descending);
-              },
-            ),
+            itemBuilder: (context, item) {
+              final targetCommentId = widget.targetCommentId;
+              return KeyedSubtree(
+                key: _commentKeys.putIfAbsent(item.id, GlobalKey.new),
+                child: CommentItem(
+                  comment: item,
+                  showMenu: loginUser == item.user,
+                  highlighted: targetCommentId == item.id,
+                  onEdit: () {
+                    ref
+                        .read(topicDetailProvider(widget.topicId).notifier)
+                        .refresh(descending: descending);
+                  },
+                ),
+              );
+            },
             onFetch: () {
               ref
                   .read(topicDetailProvider(widget.topicId).notifier)
@@ -370,6 +405,29 @@ class _TopicDetailScreenState extends ConsumerState<TopicDetailScreen> {
               },
             ),
     );
+  }
+
+  void _scrollToTargetComment(TopicDetailState state) {
+    final targetCommentId = widget.targetCommentId;
+    if (targetCommentId == null || targetCommentId.isEmpty) return;
+    if (_scrolledTargetCommentId == targetCommentId) return;
+    if (state.status != TopicDetailStatus.success) return;
+    if (!state.comments.any((comment) => comment.id == targetCommentId)) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final context = _commentKeys[targetCommentId]?.currentContext;
+      if (context == null) return;
+      Scrollable.ensureVisible(
+        context,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
+        alignment: 0.25,
+      );
+      _scrolledTargetCommentId = targetCommentId;
+    });
   }
 }
 

--- a/lib/board/view/widgets/comment_item.dart
+++ b/lib/board/view/widgets/comment_item.dart
@@ -11,75 +11,82 @@ import 'package:smarthome/widgets/markdown.dart';
 class CommentItem extends ConsumerWidget {
   final Comment comment;
   final bool showMenu;
+  final bool highlighted;
   final void Function()? onEdit;
 
   const CommentItem({
     super.key,
     required this.comment,
     required this.showMenu,
+    this.highlighted = false,
     this.onEdit,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        ItemTitle(
-          user: comment.user!,
-          createdAt: comment.createdAt!,
-          editedAt: comment.editedAt!,
-          onSelected: showMenu
-              ? (Menu menu) async {
-                  switch (menu) {
-                    case Menu.delete:
-                      await showDialog(
-                        context: context,
-                        builder: (_) => AlertDialog(
-                          title: const Text('删除评论'),
-                          content: const Text('你确认要删除该评论？'),
-                          actions: <Widget>[
-                            TextButton(
-                              onPressed: () {
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text('否'),
-                            ),
-                            TextButton(
-                              onPressed: () {
-                                showInfoSnackBar('正在删除...', duration: 1);
-                                ref
-                                    .read(commentEditProvider.notifier)
-                                    .deleteComment(comment);
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text('是'),
-                            ),
-                          ],
-                        ),
-                      );
-                      break;
-                    case Menu.edit:
-                      final r = await Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (_) => CommentEditPage(
-                            isEditing: true,
-                            comment: comment,
+    final colorScheme = Theme.of(context).colorScheme;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      color: highlighted ? colorScheme.secondaryContainer : null,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          ItemTitle(
+            user: comment.user!,
+            createdAt: comment.createdAt!,
+            editedAt: comment.editedAt!,
+            onSelected: showMenu
+                ? (Menu menu) async {
+                    switch (menu) {
+                      case Menu.delete:
+                        await showDialog(
+                          context: context,
+                          builder: (_) => AlertDialog(
+                            title: const Text('删除评论'),
+                            content: const Text('你确认要删除该评论？'),
+                            actions: <Widget>[
+                              TextButton(
+                                onPressed: () {
+                                  Navigator.of(context).pop();
+                                },
+                                child: const Text('否'),
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  showInfoSnackBar('正在删除...', duration: 1);
+                                  ref
+                                      .read(commentEditProvider.notifier)
+                                      .deleteComment(comment);
+                                  Navigator.of(context).pop();
+                                },
+                                child: const Text('是'),
+                              ),
+                            ],
                           ),
-                        ),
-                      );
-                      if (r == true && onEdit != null) onEdit!();
-                      break;
+                        );
+                        break;
+                      case Menu.edit:
+                        final r = await Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => CommentEditPage(
+                              isEditing: true,
+                              comment: comment,
+                            ),
+                          ),
+                        );
+                        if (r == true && onEdit != null) onEdit!();
+                        break;
+                    }
                   }
-                }
-              : null,
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
-          child: MyMarkdownBody(data: comment.body!),
-        ),
-      ],
+                : null,
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+            child: MyMarkdownBody(data: comment.body!),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -24,6 +24,7 @@ class AppRoutes {
   // 留言板
   static const String board = '/board';
   static const String topicDetail = '/topic/:id';
+  static const String commentDetail = '/comment/:id';
 
   // 博客
   static const String blog = '/blog';
@@ -50,6 +51,8 @@ class AppRoutes {
   static String itemDetailPath(String itemId) => '/item/$itemId';
 
   static String topicDetailPath(String topicId) => '/topic/$topicId';
+
+  static String commentDetailPath(String commentId) => '/comment/$commentId';
 
   static String pictureDetailPath(String pictureId) => '/picture/$pictureId';
 }

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -44,7 +44,10 @@ final routerProvider = Provider<GoRouter>((ref) {
 
       // 登录状态检查
       if (!isLogin && state.matchedLocation != AppRoutes.login) {
-        return AppRoutes.login;
+        return Uri(
+          path: AppRoutes.login,
+          queryParameters: {'next': state.uri.toString()},
+        ).toString();
       }
       if (isLogin &&
           (state.matchedLocation == AppRoutes.login ||
@@ -101,6 +104,15 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) {
           final id = state.pathParameters['id'] ?? '';
           return TopicDetailPage(topicId: id);
+        },
+      ),
+
+      // 评论详情
+      GoRoute(
+        path: AppRoutes.commentDetail,
+        builder: (context, state) {
+          final id = state.pathParameters['id'] ?? '';
+          return CommentLinkPage(commentId: id);
         },
       ),
 

--- a/test/board/providers/topic_detail_provider_test.dart
+++ b/test/board/providers/topic_detail_provider_test.dart
@@ -61,6 +61,56 @@ void main() {
     expect(state.comments, hasLength(1));
   });
 
+  test('commentProvider loads comment context', () async {
+    final topic = buildTopic(id: 'topic-1');
+    when(
+      mockBoardRepository.comment(commentId: 'comment-1'),
+    ).thenAnswer((_) async => buildComment(id: 'comment-1', topic: topic));
+
+    final comment = await container.read(commentProvider('comment-1').future);
+
+    expect(comment.id, 'comment-1');
+    expect(comment.topic?.id, 'topic-1');
+  });
+
+  test(
+    'initialize fetches more pages until target comment is available',
+    () async {
+      when(
+        mockBoardRepository.topicDetail(
+          topicId: anyNamed('topicId'),
+          descending: anyNamed('descending'),
+          cache: anyNamed('cache'),
+          after: anyNamed('after'),
+        ),
+      ).thenAnswer((invocation) async {
+        final after =
+            invocation.namedArguments[const Symbol('after')] as String?;
+        if (after == 'cursor-1') {
+          return Tuple3(
+            buildTopic(id: 'topic-1'),
+            [buildComment(id: 'comment-2')],
+            const PageInfo(hasNextPage: false, endCursor: 'cursor-2'),
+          );
+        }
+        return Tuple3(
+          buildTopic(id: 'topic-1'),
+          [buildComment(id: 'comment-1')],
+          const PageInfo(hasNextPage: true, endCursor: 'cursor-1'),
+        );
+      });
+
+      final provider = topicDetailProvider('topic-1');
+      keepProviderAlive(container, provider);
+      await container
+          .read(provider.notifier)
+          .initialize(targetCommentId: 'comment-2');
+
+      final state = container.read(provider);
+      expect(state.comments.map((e) => e.id), ['comment-1', 'comment-2']);
+    },
+  );
+
   test('fetchMore appends additional comments', () async {
     when(
       mockBoardRepository.topicDetail(

--- a/test/helpers/board_test_utils.dart
+++ b/test/helpers/board_test_utils.dart
@@ -3,5 +3,5 @@ import 'package:smarthome/board/model/board.dart';
 Topic buildTopic({String id = 'topic-1', List<Comment>? comments}) =>
     Topic(id: id, title: 'Topic $id', comments: comments);
 
-Comment buildComment({String id = 'comment-1'}) =>
-    Comment(id: id, body: 'Comment $id');
+Comment buildComment({String id = 'comment-1', Topic? topic}) =>
+    Comment(id: id, topic: topic, body: 'Comment $id');

--- a/test/mocks/mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.dart
@@ -1133,6 +1133,19 @@ class MockBoardRepository extends _i1.Mock implements _i20.BoardRepository {
           as _i3.GraphQLApiClient);
 
   @override
+  _i17.Future<_i7.Comment> comment({required String? commentId}) =>
+      (super.noSuchMethod(
+            Invocation.method(#comment, [], {#commentId: commentId}),
+            returnValue: _i17.Future<_i7.Comment>.value(
+              _FakeComment_7(
+                this,
+                Invocation.method(#comment, [], {#commentId: commentId}),
+              ),
+            ),
+          )
+          as _i17.Future<_i7.Comment>);
+
+  @override
   _i17.Future<_i7.Comment> addComment({
     required String? topicId,
     required String? body,


### PR DESCRIPTION
## 变更

- 新增 `/comment/:id` 路由，支持通过评论 global id 打开对应评论
- 新增评论查询，通过 Relay `node(id:)` 获取评论和所属话题
- 话题详情页支持加载分页直到目标评论出现，然后滚动并高亮目标评论
- 未登录访问深链时保留 `next`，登录后回到原目标
- 补充 provider 测试并更新 mock/generated provider 文件

## 背景

响应 #137，支持类似 `/comment/Q29tbWVudFR5cGU6Mg==` 的链接直达评论。

## 验证

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze --no-pub`
- `flutter test --no-pub test\board\providers`
- `flutter test --no-pub`

## 注意

当前实现假设后端暴露 Relay `node(id:)` 且评论类型为 `CommentType`，与 issue 示例 global id 的类型名一致。真实后端仍建议手动点一次深链确认。
