### PR TITLE
feat(storage): 添加搜索历史记录

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -30,3 +30,8 @@ linter:
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+analyzer:
+  exclude:
+    - build/**
+    - .dart_tool/**
+    - .sentry-native/**

--- a/lib/core/repository/settings_repository.dart
+++ b/lib/core/repository/settings_repository.dart
@@ -13,6 +13,8 @@ import 'package:smarthome/user/model/user.dart';
 /// persist the user settings locally, use the shared_preferences package. If
 /// you'd like to store settings on a web server, use the http package.
 class SettingsRepository {
+  static const int maxSearchHistoryLength = 20;
+
   final Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
 
   Future<ThemeMode> themeMode() async {
@@ -191,5 +193,23 @@ class SettingsRepository {
   Future<void> updateLoginMethod(String method) async {
     final prefs = await _prefs;
     prefs.setString('loginMethod', method);
+  }
+
+  Future<List<String>> searchHistory() async {
+    final prefs = await _prefs;
+    return prefs.getStringList('searchHistory') ?? const [];
+  }
+
+  Future<void> updateSearchHistory(List<String> history) async {
+    final prefs = await _prefs;
+    await prefs.setStringList(
+      'searchHistory',
+      history.take(maxSearchHistoryLength).toList(),
+    );
+  }
+
+  Future<void> clearSearchHistory() async {
+    final prefs = await _prefs;
+    await prefs.remove('searchHistory');
   }
 }

--- a/lib/storage/providers/search_provider.dart
+++ b/lib/storage/providers/search_provider.dart
@@ -12,6 +12,7 @@ class SearchState {
   final List<Item> items;
   final List<Storage> storages;
   final String term;
+  final List<String> history;
 
   const SearchState({
     this.status = SearchStatus.initial,
@@ -19,6 +20,7 @@ class SearchState {
     this.items = const [],
     this.storages = const [],
     this.term = '',
+    this.history = const [],
   });
 
   SearchState copyWith({
@@ -27,6 +29,7 @@ class SearchState {
     List<Item>? items,
     List<Storage>? storages,
     String? term,
+    List<String>? history,
   }) {
     return SearchState(
       status: status ?? this.status,
@@ -34,6 +37,7 @@ class SearchState {
       items: items ?? this.items,
       storages: storages ?? this.storages,
       term: term ?? this.term,
+      history: history ?? this.history,
     );
   }
 
@@ -59,7 +63,7 @@ class Search extends _$Search {
     bool missingStorage = false,
   }) async {
     if (key.isEmpty) {
-      state = const SearchState();
+      state = SearchState(history: state.history);
       return;
     }
 
@@ -73,6 +77,7 @@ class Search extends _$Search {
         missingStorage: missingStorage,
       );
       if (!ref.mounted) return;
+      await _saveSearchHistory(key);
       state = state.copyWith(
         status: SearchStatus.success,
         items: results.item1,
@@ -86,5 +91,35 @@ class Search extends _$Search {
         errorMessage: e.message,
       );
     }
+  }
+
+  Future<void> loadHistory() async {
+    final settingsRepository = ref.read(settingsRepositoryProvider);
+    final history = await settingsRepository.searchHistory();
+    if (!ref.mounted) return;
+    state = state.copyWith(history: history);
+  }
+
+  Future<void> removeHistory(String key) async {
+    final history = state.history.where((item) => item != key).toList();
+    state = state.copyWith(history: history);
+    await ref.read(settingsRepositoryProvider).updateSearchHistory(history);
+  }
+
+  Future<void> clearHistory() async {
+    state = state.copyWith(history: const []);
+    await ref.read(settingsRepositoryProvider).clearSearchHistory();
+  }
+
+  Future<void> _saveSearchHistory(String key) async {
+    final trimmedKey = key.trim();
+    if (trimmedKey.isEmpty) return;
+
+    final history = [
+      trimmedKey,
+      ...state.history.where((item) => item != trimmedKey),
+    ].take(SettingsRepository.maxSearchHistoryLength).toList();
+    state = state.copyWith(history: history);
+    await ref.read(settingsRepositoryProvider).updateSearchHistory(history);
   }
 }

--- a/lib/storage/providers/search_provider.g.dart
+++ b/lib/storage/providers/search_provider.g.dart
@@ -43,7 +43,7 @@ final class SearchProvider extends $NotifierProvider<Search, SearchState> {
   }
 }
 
-String _$searchHash() => r'b624418729a74e253acc5ed23f0a69b925b2197e';
+String _$searchHash() => r'15e011dfaa67d50f8410dd2a867f559b6a0b50b9';
 
 /// Search notifier
 

--- a/lib/storage/view/search_page.dart
+++ b/lib/storage/view/search_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:smarthome/storage/providers/search_provider.dart';
 import 'package:smarthome/storage/view/widgets/storage_item_list.dart';
@@ -77,88 +76,82 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return KeyboardDismissOnTap(
-      child: MySliverScaffold(
-        appBarSize: AppBarSize.normal,
-        title: TextField(
-          decoration: InputDecoration(
-            hintText: '搜索',
-            suffixIcon: _showClearButton
-                ? IconButton(
-                    icon: Icon(
-                      Icons.clear,
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
-                    onPressed: () {
-                      _textController.text = '';
-                    },
-                  )
-                : null,
-            border: InputBorder.none,
-          ),
-          autofocus: true,
-          controller: _textController,
+    return MySliverScaffold(
+      appBarSize: AppBarSize.normal,
+      title: SearchBar(
+        hintText: '搜索',
+        leading: const Icon(Icons.search),
+        trailing: [
+          if (_showClearButton)
+            IconButton(
+              icon: const Icon(Icons.clear),
+              tooltip: '清除',
+              onPressed: _textController.clear,
+            ),
+        ],
+        autoFocus: true,
+        controller: _textController,
+        onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
+      ),
+      appbarBottom: PreferredSize(
+        preferredSize: const Size.fromHeight(48),
+        child: Row(
+          children: [
+            MyChoiceChip(
+              label: const Text('已删除'),
+              selected: _isDeleted,
+              onSelected: (value) {
+                setState(() {
+                  _isDeleted = value;
+                  doSearch();
+                });
+              },
+            ),
+            MyChoiceChip(
+              label: const Text('无位置'),
+              selected: _missingStorage,
+              onSelected: (value) {
+                setState(() {
+                  _missingStorage = value;
+                  doSearch();
+                });
+              },
+            ),
+          ],
         ),
-        appbarBottom: PreferredSize(
-          preferredSize: const Size.fromHeight(48),
-          child: Row(
-            children: [
-              MyChoiceChip(
-                label: const Text('已删除'),
-                selected: _isDeleted,
-                onSelected: (value) {
-                  setState(() {
-                    _isDeleted = value;
-                    doSearch();
-                  });
-                },
-              ),
-              MyChoiceChip(
-                label: const Text('无位置'),
-                selected: _missingStorage,
-                onSelected: (value) {
-                  setState(() {
-                    _missingStorage = value;
-                    doSearch();
-                  });
-                },
-              ),
-            ],
-          ),
-        ),
-        sliver: Consumer(
-          builder: (BuildContext context, WidgetRef ref, _) {
-            final state = ref.watch(searchProvider);
-            if (state.status == SearchStatus.loading) {
-              return const SliverCenterLoadingIndicator();
+      ),
+      sliver: Consumer(
+        builder: (BuildContext context, WidgetRef ref, _) {
+          final state = ref.watch(searchProvider);
+          if (state.status == SearchStatus.loading) {
+            return const SliverCenterLoadingIndicator();
+          }
+          if (state.status == SearchStatus.failure) {
+            return SliverCenterMessage(message: state.errorMessage);
+          }
+          if (state.status == SearchStatus.success) {
+            if (state.items.isEmpty && state.storages.isEmpty) {
+              return const SliverCenterMessage(message: '无结果');
+            } else {
+              return StorageItemList(
+                items: state.items,
+                storages: state.storages,
+                isHighlight: true,
+                term: state.term,
+              );
             }
-            if (state.status == SearchStatus.failure) {
-              return SliverCenterMessage(message: state.errorMessage);
-            }
-            if (state.status == SearchStatus.success) {
-              if (state.items.isEmpty && state.storages.isEmpty) {
-                return const SliverCenterMessage(message: '无结果');
-              } else {
-                return StorageItemList(
-                  items: state.items,
-                  storages: state.storages,
-                  isHighlight: true,
-                  term: state.term,
-                );
-              }
-            }
-            return SliverFillRemaining(
-              hasScrollBody: false,
-              child: _SearchHistoryList(
-                history: state.history,
-                onTap: _searchHistory,
-                onRemove: (key) =>
-                    ref.read(searchProvider.notifier).removeHistory(key),
-                onClear: () => ref.read(searchProvider.notifier).clearHistory(),
-              ),
-            );
-          },
-        ),
+          }
+          return SliverFillRemaining(
+            hasScrollBody: false,
+            child: _SearchHistoryList(
+              history: state.history,
+              onTap: _searchHistory,
+              onRemove: (key) =>
+                  ref.read(searchProvider.notifier).removeHistory(key),
+              onClear: () => ref.read(searchProvider.notifier).clearHistory(),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/storage/view/search_page.dart
+++ b/lib/storage/view/search_page.dart
@@ -37,6 +37,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   @override
   void initState() {
     super.initState();
+    Future.microtask(() => ref.read(searchProvider.notifier).loadHistory());
     _textController.addListener(() {
       setState(() {
         if (_textController.text.isNotEmpty) _showClearButton = true;
@@ -56,14 +57,22 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   void doSearch() {
     _debounceTimer?.cancel();
     _debounceTimer = Timer(const Duration(milliseconds: 300), () {
-      ref
-          .read(searchProvider.notifier)
-          .search(
-            _textController.text,
-            isDeleted: _isDeleted,
-            missingStorage: _missingStorage,
-          );
+      _search(_textController.text);
     });
+  }
+
+  void _search(String key) {
+    ref
+        .read(searchProvider.notifier)
+        .search(key, isDeleted: _isDeleted, missingStorage: _missingStorage);
+  }
+
+  void _searchHistory(String key) {
+    _debounceTimer?.cancel();
+    _textController.text = key;
+    _textController.selection = TextSelection.collapsed(offset: key.length);
+    _debounceTimer?.cancel();
+    _search(key);
   }
 
   @override
@@ -140,11 +149,59 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
             }
             return SliverFillRemaining(
               hasScrollBody: false,
-              child: Container(),
+              child: _SearchHistoryList(
+                history: state.history,
+                onTap: _searchHistory,
+                onRemove: (key) =>
+                    ref.read(searchProvider.notifier).removeHistory(key),
+                onClear: () => ref.read(searchProvider.notifier).clearHistory(),
+              ),
             );
           },
         ),
       ),
+    );
+  }
+}
+
+class _SearchHistoryList extends StatelessWidget {
+  final List<String> history;
+  final ValueChanged<String> onTap;
+  final ValueChanged<String> onRemove;
+  final VoidCallback onClear;
+
+  const _SearchHistoryList({
+    required this.history,
+    required this.onTap,
+    required this.onRemove,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (history.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: [
+        ListTile(
+          title: Text('搜索历史', style: Theme.of(context).textTheme.titleMedium),
+          trailing: TextButton(onPressed: onClear, child: const Text('清空')),
+        ),
+        for (final key in history)
+          ListTile(
+            leading: const Icon(Icons.history),
+            title: Text(key),
+            onTap: () => onTap(key),
+            trailing: IconButton(
+              tooltip: '删除',
+              icon: const Icon(Icons.close),
+              onPressed: () => onRemove(key),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -414,55 +414,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
-  flutter_keyboard_visibility:
-    dependency: "direct main"
-    description:
-      name: flutter_keyboard_visibility
-      sha256: "98664be7be0e3ffca00de50f7f6a287ab62c763fc8c762e0a21584584a3ff4f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
-  flutter_keyboard_visibility_linux:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_linux
-      sha256: "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  flutter_keyboard_visibility_macos:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_macos
-      sha256: c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  flutter_keyboard_visibility_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_platform_interface
-      sha256: e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
-  flutter_keyboard_visibility_web:
-    dependency: "direct overridden"
-    description:
-      path: flutter_keyboard_visibility_web
-      ref: master
-      resolved-ref: "3b13b9f65dc4cbddb20022c29c95f92180503285"
-      url: "https://github.com/raldhafiri/flutter_keyboard_visibility.git"
-    source: git
-    version: "2.0.1"
-  flutter_keyboard_visibility_windows:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility_windows
-      sha256: fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   device_info_plus: ^13.1.0
   package_info_plus: ^10.1.0
   share_plus: ^13.1.0
-  flutter_keyboard_visibility: ^6.0.0
   image_picker: ^1.2.1
   sentry_flutter: ^9.8.0
   dynamic_color: ^1.8.1
@@ -60,14 +59,6 @@ dependencies:
   mobile_scanner: ^7.1.3
   photo_view: ^0.15.0
   qr_flutter: ^4.1.0
-
-# https://github.com/MisterJimson/flutter_keyboard_visibility/pull/155#issuecomment-2112047514
-dependency_overrides:
-  flutter_keyboard_visibility_web:
-    git:
-      url: https://github.com/raldhafiri/flutter_keyboard_visibility.git
-      ref: master
-      path: flutter_keyboard_visibility_web
 
 dev_dependencies:
   flutter_test:

--- a/test/core/repository/settings_repository_test.dart
+++ b/test/core/repository/settings_repository_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:smarthome/core/repository/settings_repository.dart';
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  test('searchHistory returns saved terms', () async {
+    SharedPreferences.setMockInitialValues({
+      'searchHistory': ['keyboard', 'router'],
+    });
+    final repository = SettingsRepository();
+
+    expect(await repository.searchHistory(), ['keyboard', 'router']);
+  });
+
+  test('updateSearchHistory limits saved terms', () async {
+    final repository = SettingsRepository();
+    final terms = List.generate(25, (index) => 'term-$index');
+
+    await repository.updateSearchHistory(terms);
+
+    expect(await repository.searchHistory(), terms.take(20));
+  });
+
+  test('clearSearchHistory removes saved terms', () async {
+    SharedPreferences.setMockInitialValues({
+      'searchHistory': ['keyboard'],
+    });
+    final repository = SettingsRepository();
+
+    await repository.clearSearchHistory();
+
+    expect(await repository.searchHistory(), isEmpty);
+  });
+}

--- a/test/mocks/mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.dart
@@ -564,6 +564,32 @@ class MockSettingsRepository extends _i1.Mock
             returnValueForMissingStub: _i17.Future<void>.value(),
           )
           as _i17.Future<void>);
+
+  @override
+  _i17.Future<List<String>> searchHistory() =>
+      (super.noSuchMethod(
+            Invocation.method(#searchHistory, []),
+            returnValue: _i17.Future<List<String>>.value(<String>[]),
+          )
+          as _i17.Future<List<String>>);
+
+  @override
+  _i17.Future<void> updateSearchHistory(List<String>? history) =>
+      (super.noSuchMethod(
+            Invocation.method(#updateSearchHistory, [history]),
+            returnValue: _i17.Future<void>.value(),
+            returnValueForMissingStub: _i17.Future<void>.value(),
+          )
+          as _i17.Future<void>);
+
+  @override
+  _i17.Future<void> clearSearchHistory() =>
+      (super.noSuchMethod(
+            Invocation.method(#clearSearchHistory, []),
+            returnValue: _i17.Future<void>.value(),
+            returnValueForMissingStub: _i17.Future<void>.value(),
+          )
+          as _i17.Future<void>);
 }
 
 /// A class which mocks [StorageRepository].

--- a/test/storage/providers/search_provider_test.dart
+++ b/test/storage/providers/search_provider_test.dart
@@ -11,13 +11,21 @@ import '../../mocks/mocks.mocks.dart';
 
 void main() {
   late MockStorageRepository mockStorageRepository;
+  late MockSettingsRepository mockSettingsRepository;
   late ProviderContainer container;
 
   setUp(() {
     mockStorageRepository = MockStorageRepository();
+    mockSettingsRepository = MockSettingsRepository();
+    when(mockSettingsRepository.searchHistory()).thenAnswer((_) async => []);
+    when(
+      mockSettingsRepository.updateSearchHistory(any),
+    ).thenAnswer((_) async {});
+    when(mockSettingsRepository.clearSearchHistory()).thenAnswer((_) async {});
     container = ProviderContainer.test(
       overrides: [
         storageRepositoryProvider.overrideWithValue(mockStorageRepository),
+        settingsRepositoryProvider.overrideWithValue(mockSettingsRepository),
       ],
     );
   });
@@ -60,6 +68,7 @@ void main() {
     final state = container.read(searchProvider);
     expect(state.status, SearchStatus.initial);
     expect(state.items, isEmpty);
+    expect(state.history, isEmpty);
   });
 
   test('search surfaces repository errors', () async {
@@ -76,5 +85,76 @@ void main() {
     final state = container.read(searchProvider);
     expect(state.status, SearchStatus.failure);
     expect(state.errorMessage, '搜索失败');
+  });
+
+  test('loadHistory reads saved search history', () async {
+    when(
+      mockSettingsRepository.searchHistory(),
+    ).thenAnswer((_) async => ['keyboard', 'router']);
+
+    await container.read(searchProvider.notifier).loadHistory();
+
+    expect(container.read(searchProvider).history, ['keyboard', 'router']);
+  });
+
+  test('search saves successful terms to history', () async {
+    when(
+      mockStorageRepository.search(
+        any,
+        isDeleted: anyNamed('isDeleted'),
+        missingStorage: anyNamed('missingStorage'),
+      ),
+    ).thenAnswer((_) async => const Tuple2([], []));
+
+    await container.read(searchProvider.notifier).loadHistory();
+    await container.read(searchProvider.notifier).search('keyboard');
+
+    expect(container.read(searchProvider).history, ['keyboard']);
+    verify(mockSettingsRepository.updateSearchHistory(['keyboard'])).called(1);
+  });
+
+  test('search moves repeated terms to the front', () async {
+    when(
+      mockSettingsRepository.searchHistory(),
+    ).thenAnswer((_) async => ['router', 'keyboard']);
+    when(
+      mockStorageRepository.search(
+        any,
+        isDeleted: anyNamed('isDeleted'),
+        missingStorage: anyNamed('missingStorage'),
+      ),
+    ).thenAnswer((_) async => const Tuple2([], []));
+
+    await container.read(searchProvider.notifier).loadHistory();
+    await container.read(searchProvider.notifier).search('keyboard');
+
+    expect(container.read(searchProvider).history, ['keyboard', 'router']);
+    verify(
+      mockSettingsRepository.updateSearchHistory(['keyboard', 'router']),
+    ).called(1);
+  });
+
+  test('removeHistory deletes a single saved term', () async {
+    when(
+      mockSettingsRepository.searchHistory(),
+    ).thenAnswer((_) async => ['router', 'keyboard']);
+
+    await container.read(searchProvider.notifier).loadHistory();
+    await container.read(searchProvider.notifier).removeHistory('router');
+
+    expect(container.read(searchProvider).history, ['keyboard']);
+    verify(mockSettingsRepository.updateSearchHistory(['keyboard'])).called(1);
+  });
+
+  test('clearHistory removes all saved terms', () async {
+    when(
+      mockSettingsRepository.searchHistory(),
+    ).thenAnswer((_) async => ['router']);
+
+    await container.read(searchProvider.notifier).loadHistory();
+    await container.read(searchProvider.notifier).clearHistory();
+
+    expect(container.read(searchProvider).history, isEmpty);
+    verify(mockSettingsRepository.clearSearchHistory()).called(1);
   });
 }


### PR DESCRIPTION
## 变更

- 在设置仓库中持久化搜索历史，最多保留 20 条
- 搜索 provider 支持加载、保存、删除和清空历史
- 搜索页空状态展示历史记录，点击历史词可重新搜索
- 补充设置仓库和搜索 provider 测试，并更新生成文件

## 背景

响应 #141，在移动端/本地保存搜索历史记录。

## 验证

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze --no-pub`
- `flutter test --no-pub`
